### PR TITLE
Feature/large memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 **/*.dis
 **/*.sym
 **/*.elf
+.vscode/*

--- a/code/software/Makefile
+++ b/code/software/Makefile
@@ -3,18 +3,29 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
-SOFTWARE := $(filter-out libs/.,$(wildcard */.))
+LIBSTARG = clean all install
+SOFTWARETARG = clean all
+
+SOFTWARE := $(subst /.,,$(filter-out libs/.,$(wildcard */.)))
 
 all: libs $(SOFTWARE)
 
+clean: LIBSTARG = clean
+clean: SOFTWARETARG = clean
+clean: libs $(SOFTWARE)
+
 libs:
-				@echo === Rebuilding and installing rosco_m68k libraries
-				$(MAKE) -C libs clean all install
+				@echo =
+				@echo === installing rosco_m68k libs
+				@echo = 
+				$(MAKE) -C libs $(LIBSTARG)
 
 software: $(SOFTWARE)
 
 $(SOFTWARE): libs
-				@echo === Rebuilding $@
-				$(MAKE)	-C $@ clean all
+				@echo =
+				@echo = $@
+				@echo = 
+				$(MAKE)	-C $@ $(SOFTWARETARG)
 
-.PHONY:	all libs $(SOFTWARE)
+.PHONY:	all clean libs $(SOFTWARE)

--- a/code/software/Makefile
+++ b/code/software/Makefile
@@ -3,12 +3,12 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
-SOFTWARE := $(filter-out libs,$(wildcard */.))
+SOFTWARE := $(filter-out libs/.,$(wildcard */.))
 
 all: libs $(SOFTWARE)
 
 libs:
-				@echo === Rebuilding and installing rosco_m68 libraries
+				@echo === Rebuilding and installing rosco_m68k libraries
 				$(MAKE) -C libs clean all install
 
 software: $(SOFTWARE)

--- a/code/software/ehbasic/Makefile
+++ b/code/software/ehbasic/Makefile
@@ -19,7 +19,7 @@ LST=$(BINARY_BASENAME).lst
 BINARY=$(BINARY_BASENAME).$(BINARY_EXT)
 
 $(BINARY) : ehbasic.S ehdefs.S
-	vasmm68k_mot -Fbin -m68010 -nowarn=2028 -L $(LST) -o $(BINARY) ehbasic.S
+	vasmm68k_mot -quiet -Fbin -m68010 -nowarn=2028 -L $(LST) -o $(BINARY) ehbasic.S
 	chmod a-x $@
 
 .PHONY: all clean load

--- a/code/software/ehbasic/README.md
+++ b/code/software/ehbasic/README.md
@@ -38,5 +38,4 @@ References:
  For more information on EhBASIC68, other versions of EhBASIC and other projects
  please visit my site at ..
 
-	 http://mycorner.no-ip.org/index.html
-
+  http://mycorner.no-ip.org/index.html

--- a/code/software/gpio-interrupt/Makefile
+++ b/code/software/gpio-interrupt/Makefile
@@ -3,7 +3,7 @@
 # Copyright (c)2020 Xark
 # MIT LICENSE
 
-EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer -fverbose-asm
+EXTRA_CFLAGS?=-g -Os -fomit-frame-pointer
 DEFINES=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -13,7 +13,7 @@ CFLAGS=-std=c11 -ffreestanding -ffunction-sections -fdata-sections \
 				-mcpu=68010 -march=68010 -mtune=68010 $(DEFINES)
 ASFLAGS=-mcpu=68010 -march=68010
 LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)  --gc-sections --oformat=elf32-m68k
+				-Map=$(MAP) --gc-sections --oformat=elf32-m68k --defsym=_RAM_SIZE=1M
 VASMFLAGS=-Felf -m68010 -quiet -Lnf -showopt $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/software/libs/src/gpio/include/gpio.h
+++ b/code/software/libs/src/gpio/include/gpio.h
@@ -49,17 +49,28 @@ typedef enum GPIOMode {
 } PINMODE; 
 
 #ifndef ROSCOM68K_QUIET_INCLUDES
-#define LED_GREEN led_green
-#define LED_RED   led_red
-#define GPIO1     pin_gpio1
-#define GPIO2     pin_gpio2
-#define GPIO3     pin_gpio3
-#define GPIO4     pin_gpio4
-#define GPIO5     pin_gpio5
-#define UART_CTS  pin_cts
+
+#define LED_GREEN   led_green
+#define LED_RED     led_red
+#define GPIO1       pin_gpio1
+#define GPIO2       pin_gpio2
+#define GPIO3       pin_gpio3
+#define GPIO4       pin_gpio4
+#define GPIO5       pin_gpio5
+#define UART_CTS    pin_cts
+
+#define LED_GREEN_B led_green_b
+#define LED_RED_B   led_red_b
+#define GPIO1_B     pin_gpio1_b
+#define GPIO2_B     pin_gpio2_b
+#define GPIO3_B     pin_gpio3_b
+#define GPIO4_B     pin_gpio4_b
+#define GPIO5_B     pin_gpio5_b
+#define UART_CTS_B  pin_cts_b
 
 #define INPUT     pin_mode_input
 #define OUTPUT    pin_mode_output
+
 #endif
 
 void pinMode(GPIO pin, PINMODE mode);

--- a/code/software/libs/src/machine/include/machine.h
+++ b/code/software/libs/src/machine/include/machine.h
@@ -73,6 +73,16 @@
 #endif
 
 /*
+ * Absolute symbols defined in linker script
+ */
+extern volatile uint32_t  _TIMER_100HZ;         // 100Hz timer counter
+extern void             (*_MFP_VECTORS[16])();  // MFP interrupt vectors
+extern uint32_t           _FIRMWARE_REV;        // rosco ROM firmware rev.
+
+extern char _STACK_TOP[];     /* default stack at top of RAM  */
+extern char _HEAP_END[];      /* heap end at stack */
+
+/*
  * Early print null-terminated string.
  */
 void mcPrint(char *str);
@@ -93,6 +103,11 @@ char mcReadchar();
  *   ~1.80 usec per tick with 10Mhz CPU
  */
 void mcBusywait(uint32_t ticks);
+
+/*
+ * Delay for n 10ms ticks (using 100Hz timer interrupt)
+ */
+void mcDelaymsec10(uint32_t ticks10ms);
 
 /*
  * Disable all interrupts (except NMI).

--- a/code/software/libs/src/machine/machine.S
+++ b/code/software/libs/src/machine/machine.S
@@ -85,7 +85,7 @@ mcBusywait::
     section .text.mcDelaymsec10
 mcDelaymsec10::
     move.l  (4,A7),D0                 ; Get 10ms delay count from the stack into D0
-		add.l		_TIMER_100HZ.w,D0         ; add to current timer counter for time finished
+    add.l   _TIMER_100HZ.w,D0         ; add to current timer counter for time finished
 .DELAYWAIT
     cmp.l   _TIMER_100HZ.w,D0         ; compare current time with time finished
     bcc.s   .DELAYWAIT                ;  ... while it's < (unsigned)

--- a/code/software/libs/src/machine/machine.S
+++ b/code/software/libs/src/machine/machine.S
@@ -11,12 +11,12 @@
 ; System call implementations 
 ;------------------------------------------------------------
 
-    section .text
 
 ; Call the PRINT function of the firmware
 ;
 ; Trashes: MFP_UDR
 ; Modifies: Nothing
+    section .text.mcPrint
 mcPrint::
     movem.l D0-D1/A0,-(A7)            ; Save regs
     move.l  (16,A7),A0                ; Get C char* from the stack into A0
@@ -29,6 +29,7 @@ mcPrint::
 ;
 ; Trashes: MFP_UDR
 ; Modifies: Nothing
+    section .text.mcPrintln
 mcPrintln::
     movem.l D0-D1/A0,-(A7)            ; Save regs
     move.l  (16,A7),A0                ; Get C char* from the stack into A0
@@ -41,9 +42,10 @@ mcPrintln::
 ;
 ; Trashes: MFP_UDR
 ; Modifies: Nothing
+    section .text.mcSendchar
 mcSendchar::
     movem.l  D0-D1,-(A7)              ; Save regs
-    move.l  (12,A7),D0                ; Get C char from the stack into A0
+    move.l  (12,A7),D0                ; Get C char from the stack into D0
     move.l  #2,D1                     ; Func code is 2
     trap    #14                       ; TRAP to firmware
     movem.l (A7)+,D0-D1               ; Restore regs
@@ -54,6 +56,7 @@ mcSendchar::
 ; Trashes: MFP_UDR
 ; Modifies: D0 (return)
 
+    section .text.mcReadchar
 mcReadchar::
     move.l  D1,-(A7)                  ; Save regs
     move.l  #3,D1                     ; Func code is 2
@@ -65,8 +68,9 @@ mcReadchar::
 ; 
 ; Trashes: D0
 ; Modifies: Nothing
+    section .text.mcBusywait
 mcBusywait::
-    move.l  (4,A7),D0                 ; Get C char* from the stack into A0
+    move.l  (4,A7),D0                 ; Get C delay count from the stack into D0
 .BUSYWAIT
     sub.l   #1,D0                     ; Keep decrementing D0...
     tst.l   D0                        ;  ... until it's zero...
@@ -74,10 +78,25 @@ mcBusywait::
     
     rts
 
+; Delay for n 10ms timer ticks
+; 
+; Trashes: D0
+; Modifies: Nothing
+    section .text.mcDelaymsec10
+mcDelaymsec10::
+    move.l  (4,A7),D0                 ; Get 10ms delay count from the stack into D0
+		add.l		_TIMER_100HZ.w,D0         ; add to current timer counter for time finished
+.DELAYWAIT
+    cmp.l   _TIMER_100HZ.w,D0         ; compare current time with time finished
+    bcc.s   .DELAYWAIT                ;  ... while it's < (unsigned)
+    
+    rts
+
 ; Disable interrupts
 ;
 ; Trashes: Nothing
 ; Modifies: SR
+    section .text.mcDisableInterrupts
 mcDisableInterrupts::
     or.w    #$0700,SR    
     rts
@@ -86,6 +105,7 @@ mcDisableInterrupts::
 ;
 ; Trashes: Nothing
 ; Modifies: SR
+    section .text.mcEnableInterrupts
 mcEnableInterrupts::
     and.w   #$F0FF,SR
     rts
@@ -95,6 +115,7 @@ mcEnableInterrupts::
 ; Trashes: Nothing
 ; Modifies: Nothing
 ; Notes: No return
+    section .text.mcHalt
 mcHalt::
     stop    #$2700
     bra.s   mcHalt

--- a/code/software/libs/src/start_serial/README.md
+++ b/code/software/libs/src/start_serial/README.md
@@ -7,7 +7,7 @@ bootloader.
 An example of linking correctly with the `serial_start` library and using
 the correct linker script might be:
 
-```
+```bash
 export LIBDIR=../libs/build
 m68k-elf-gcc -ffreestanding -o kmain.o -c kmain.c
 m68k-elf-ld T $LIBDIR/ld/serial/rosco_m68k_program.ld -L $LIBDIR -o myprog.bin main.o -lstart_serial
@@ -24,8 +24,8 @@ projects.
 
 ## Environment at entry
 
-On entry to the `kmain`, the system will be in the following state
-(some of this is provided by the firmware: see
+On entry to the `kmain`, the system will be in the following state (some of this
+is provided by the firmware: see
 https://github.com/roscopeco/rosco_m68k/tree/master/code/firmware/rosco_m68k_v1
 for details):
 
@@ -34,21 +34,30 @@ for details):
 * Exception table will be set up (with mostly no-op handlers) from $0 - $3FF
 * Code will be based at $1000, firmware data and SDB will be below this
   * Exception vectors are located at $0 to $3FF
-  * If you wish to reuse RAM from $400 to $FFF then some standard libraries can no longer be used 
-  * Some of the default exception handlers do write to this area, so change them too!
-* Supervisor stack will be at top of RAM and growing downward 
+  * If you wish to reuse RAM from $400 to $FFF then some standard libraries can
+    no longer be used
+  * Some of the default exception handlers do write to this area, so change them
+    too!
+* Supervisor stack will default to be at top of 1MiB RAM and growing downward
+  * override top of RAM using ld option "--defsym=_RAM_SIZE=2M" e.g., for 2MiB.
+  * override only stack addresss using ld option e.g., "--defsym=_RAM_SIZE=0x80000"
+  * override stack size (default 16KiB) using ld option e.g.,
+    "--defsym=_STACK_SIZE=0x1234"
 * Interrupts will be enabled
-* Bus error, address error and illegal instruction will have default handlers (that flash I1 1, 2 or 3 times in a loop)
+* Bus error, address error and illegal instruction will have default handlers
+  (that flash red LED I1 1, 2 or 3 times in a loop)
 * MFP Timer C will be driving a 100Hz system tick
 * System tick will be vectored to CPU vector 0x45, default handler flashes I0.
 * MFP Interrupts other than Timer C will be disabled
-* TRAP#14 will be hooked by the firmware to provide some basic IO (see next section)
+* TRAP#14 will be hooked by the firmware to provide some basic IO (see next
+  section)
   * This is used by the standard libraries
-* TRAP#15 will be hooked by the firmware to provide some basic IO (see next section)
+* TRAP#15 will be hooked by the firmware to provide some basic IO (see next
+  section)
   * This is used by Easy68k compatibility layer
 * UART TX and RX will be enabled, but their interrupts won't be
   * you'll either have to enable (and handle) them or use polling
-  * If you do enable them, don't use the TRAP#14 IO routines any more or sadness is likely to ensue.
+  * If you do enable them, don't use the TRAP#14 IO routines any more or sadness
+    is likely to ensue.
   * This also means not using the standard libraries for IO!
 * CTS (MFP GPIO #7) will be low (i.e. asserted).
-

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -1,58 +1,66 @@
 ;------------------------------------------------------------
-;                                  ___ ___ _   
-;  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+;                                  ___ ___ _
+;  ___ ___ ___ ___ ___       _____|  _| . | |_
 ; |  _| . |_ -|  _| . |     |     | . | . | '_|
-; |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
-;                     |_____|       firmware v1                 
+; |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+;     |_____|       firmware v1.2
 ;------------------------------------------------------------
-; Copyright (c)2020 Ross Bamford
-; See top-level LICENSE.md for licence information.
+; Copyright (c)2020 Ross Bamford See top-level LICENSE.md for licence
+; information.
 ;
-; This is the initialization code. The loader jumps into this
-; code after the "kernel" is received via serial.
+; This is the initialization code. The loader jumps into this code after the
+; "program" is received via serial.
 ;
-; The first section is position independent, but will be loaded
-; by the loader at $28000. This section copies the rest of the
-; loaded code to $1000, and then jumps to it.
+; The first section is position independent, but will be loaded by the
+; firmware loader at $00040000 (or $00028000 prior to firmware 1.2). This
+; section copies the rest of the loaded code to $1000, and then jumps to it.
 ;
-; The second section (after RELOCATED_START) is executed
-; next, based at $1000. This just calls out to __kinit to 
-; initialize .data and .bss, and then does a jump straight
-; into kmain (the user program).
+; The second section (after RELOCATED_START) is executed next, based at $1000.
+; This just calls out to __kinit to initialize .data and .bss, and then does a
+; jump straight into kmain (the user program).
 ;
-; All of this is depending on a bit of linker magic - see 
-; rosco_m68k_kernel.ld to see how that works. 
+; All of this is depending on a bit of linker magic - see rosco_m68k_kernel.ld
+; to see how that works.
 ;------------------------------------------------------------
     include "../../shared/equates.S"
 
     section .init
-; NOTE: Loaded at $28000, but copy loop has been made position-independent.
 
-; Stack and all registers can be trashed at this point,
-; the machine is your own...
+; NOTE: Loaded at $00040000 (or $00028000 in firmware prior to r1.2), but init
+; code is position-independent.
+
+; Stack and all registers can be trashed at this point, the machine is your
+; own...
 START::
-    bset.b  #1,MFP_GPDR                 ; Turn off red LED
+    bset.b  #1,MFP_GPDR           ; turn off red LED
 
-    move.l  #_STACK_TOP,A7              ; Reset stack (from linker script)
-    lea.l   RELOCATED_START(pc),A0      ; End of init PC-rel into A0 (source)
-    move.l  #_postinit,A1               ; target into A1 (destination)
+    move.l  #_STACK_TOP,A7        ; reset stack (from linker script)
 
-.COPY_LOOP:    
-    move.l  (A0)+,(A1)+                 ; Copy source to dest, with post-increment.
-    cmp.l   #_data_end,A1               ; Done?
-    bls.s   .COPY_LOOP                  ; Nope - loop again...
-  
-.COPY_DONE:
-    jmp     _postinit                   ; Jump to copied code
-
-RELOCATED_START:
+    lea.l   START(PC),A0          ; source addr, PC-rel. start (load addr)
+    lea.l   _init,A1              ; target addr, abs. start (run addr)
+    move.l  #_data_end,D0         ; use code+data length from linker
+    sub.l   A1,D0                 ; use code+data length from linker
+    lsr.l   #2,D0                 ; convert to long words
+    subq.l  #1,D0                 ; convert to zero based length for dbf
+    move.l  D0,D1                 ; copy for outer loop
+    swap    D1                    ; swap for outer 64K loop count
+.COPY_LOOP:
+    move.l  (A0)+,(A1)+           ; copy long word from source to target
+    dbra     D0,.COPY_LOOP        ; inner loop for up to 64K
+    jmp     _postinit             ; NOTE: jump to *relocated* to continue
 
     section .postinit
-    org $4000
+                                  ; NOTE: code will have been copied from
+                                  ; above, but now in new relocated segment at
+                                  ; run addr, vs load addr and copy continues
+                                  ; but, since we crossed segments, we need to
+                                  ; use manual branch offset since assembler
+                                  ; (wisely) won't branch between segments
+    dbra     D1,*-12              ; outer loop to .COPY_LOOP for > 64K
 
 PREMAIN:
-    move.l  $FC0004,-(A7)               ; Push reset vector in case kmain returns
+    move.l  $0004,-(A7)           ; push (soft) reset vector if kmain returns
     lea.l   __kinit,A0
-    jsr    (A0)
+    jsr     (A0)                  ; prepare C environment
     lea.l   kmain,A0
-    jmp     (A0)                        ; Fly user program, Fly!
+    jmp     (A0)                  ; Fly user program, Fly!

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -11,8 +11,8 @@
 ; This is the initialization code. The loader jumps into this
 ; code after the "kernel" is received via serial.
 ;
-; The first section is linked to be run at $40000, where the
-; loader loads the code. This section copies the rest of the
+; The first section is position independent, but will be loaded
+; by the loader at $28000. This section copies the rest of the
 ; loaded code to $1000, and then jumps to it.
 ;
 ; The second section (after RELOCATED_START) is executed
@@ -26,7 +26,7 @@
     include "../../shared/equates.S"
 
     section .init
-; NOTE: Loaded at $28000, but copy oop has been made position-independent.
+; NOTE: Loaded at $28000, but copy loop has been made position-independent.
 
 ; Stack and all registers can be trashed at this point,
 ; the machine is your own...
@@ -34,7 +34,7 @@ START::
     bset.b  #1,MFP_GPDR                 ; Turn off red LED
 
     move.l  #_STACK_TOP,A7              ; Reset stack (from linker script)
-    lea.l   RELOCATED_START(pc),A0      ; End of init into A0 PC-rel (source)
+    lea.l   RELOCATED_START(pc),A0      ; End of init PC-rel into A0 (source)
     move.l  #_postinit,A1               ; target into A1 (destination)
 
 .COPY_LOOP:    

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -31,32 +31,38 @@
 
 ; Stack and all registers can be trashed at this point, the machine is your
 ; own...
-START::
+
+START::                           ; position-independent load addr
     bset.b  #1,MFP_GPDR           ; turn off red LED
+    move.l  #_STACK_TOP,A7        ; reset stack from linker
 
-    move.l  #_STACK_TOP,A7        ; reset stack (from linker script)
-
-    lea.l   START(PC),A0          ; source addr, PC-rel. start (load addr)
-    lea.l   _init,A1              ; target addr, abs. start (run addr)
-    move.l  #_data_end,D0         ; use code+data length from linker
-    sub.l   A1,D0                 ; use code+data length from linker
+    lea.l   START(PC),A0          ; PC-rel source addr (load addr)
+    lea.l   _init,A1              ; absolute dest addr (run addr)
+    move.l  #_postinit_end,D0     ; init section absolute end addr
+    sub.l   A1,D0                 ; subtract dest addr for init length
     lsr.l   #2,D0                 ; convert to long words
-    subq.l  #1,D0                 ; convert to zero based length for dbf
-    move.l  D0,D1                 ; copy for outer loop
-    swap    D1                    ; swap for outer 64K loop count
-.COPY_LOOP:
-    move.l  (A0)+,(A1)+           ; copy long word from source to target
-    dbra     D0,.COPY_LOOP        ; inner loop for up to 64K
-    jmp     _postinit             ; NOTE: jump to *relocated* to continue
+    subq.l  #1,D0                 ; subtract 1 for dbra
+.INIT_LOOP:
+    move.l  (A0)+,(A1)+           ; copy long word from source to dest
+    dbra    D0,.INIT_LOOP         ; loop until end of postinit
+
+    jmp     _postinit             ; jump to copied postinit at run addr
 
     section .postinit
-                                  ; NOTE: code will have been copied from
-                                  ; above, but now in new relocated segment at
-                                  ; run addr, vs load addr and copy continues
-                                  ; but, since we crossed segments, we need to
-                                  ; use manual branch offset since assembler
-                                  ; (wisely) won't branch between segments
-    dbra     D1,*-12              ; outer loop to .COPY_LOOP for > 64K
+
+POSTINIT:                         ; running from copied run addr location
+    move.l  #_data_end,D0         ; absolute data end addr from linker
+    sub.l   A1,D0                 ; subtract dest addr for code+data length
+    lsr.l   #2,D0                 ; convert to long words
+    move.l  D0,D1                 ; copy for outer loop
+    swap    D1                    ; swap for 64K chunk count
+    bra.b   .COPY_START           ; branch to loop test first
+
+.COPY_LOOP:
+    move.l  (A0)+,(A1)+           ; copy long word from source to dest
+.COPY_START
+    dbra    D0,.COPY_LOOP         ; inner loop
+    dbra    D1,.COPY_LOOP         ; outer loop
 
 PREMAIN:
     move.l  $0004,-(A7)           ; push (soft) reset vector if kmain returns

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_kernel.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_kernel.ld
@@ -18,7 +18,7 @@ OUTPUT_FORMAT("binary")
 ENTRY(START)
 
 ram  = 0x00001000;          /* start of user memory                     */
-init = 0x01028000;          /* "pretend" high address for pos-ind. init	*/
+init = 0x01028000;          /* "pretend" high address for pos-ind. init */
 
 MEMORY
 {

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_kernel.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_kernel.ld
@@ -1,10 +1,10 @@
 /*
  *------------------------------------------------------------
- *                                  ___ ___ _   
- *  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+ *                                  ___ ___ _
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_
  * |  _| . |_ -|  _| . |     |     | . | . | '_|
- * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
- *                     |_____|       firmware v1                 
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+ *                     |_____|     firmware v1.2
  * ------------------------------------------------------------
  * Copyright (c)2020 Ross Bamford
  * See top-level LICENSE.md for licence information.
@@ -18,11 +18,9 @@ OUTPUT_FORMAT("binary")
 ENTRY(START)
 
 ram  = 0x00001000;          /* start of user memory                     */
-init = 0x01028000;          /* "pretend" high address for pos-ind. init */
 
 MEMORY
 {
-  INIT : org = init, l = 0x00010000     /* 64K for init (reused)        */ 
   RAM  : org = ram,  l = 0x00FFEFFF     /* program can use all RAM > 4K */
 }
 
@@ -40,6 +38,7 @@ PROVIDE(_EASY68K_ECHOON = 0x00000410);  /* Easy68k 'echo on' flag       */
 PROVIDE(_EASY68K_PROMPT = 0x00000411);  /* Easy68k 'prompt on' flag     */
 PROVIDE(_EASY68K_SHOWLF = 0x00000412);  /* Easy68k 'LF display' flag    */
 
+/* NOTE: These need to be kept in sync with firmware equates.S! */
 PROVIDE(_EFP_TABLE      = 0x00000420);  /* Extension function ptr table */
 
 PROVIDE(_EFP_PRINT      = 0x00000420);  /* Print string to console      */
@@ -55,16 +54,20 @@ PROVIDE(_EFP_SETCURSOR  = 0x00000440);  /* Enbable/disable cursor (opt.)*/
 /* ROM absolute addresses */
 PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
 
+/* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
+PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
+PROVIDE(_RUN_ADDRESS    = ORIGIN(RAM)); /* start of user memory         */
+
 SECTIONS
 {
-  .text.init : AT(0)
+  .text.init :
   {
     _init = .;
-    *(.init)
+    KEEP(*(.init))  /* KEEP() "anchors" section for gc-sections */
     _init_end = .;
-  } > INIT
+  } > RAM
 
-  .text.postinit : AT(SIZEOF(.text.init))
+  .text.postinit :
   {
     _postinit = .;
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
@@ -78,11 +81,12 @@ SECTIONS
     *(.rodata*)
     _code_end = .;
   } > RAM
-  
+
   .data ALIGN(4) :
   {
     _data_start = .;
     *(.data*)
+    . = ALIGN(4);   /* align for init.S longword copy */
     _data_end = .;
   } > RAM
 

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_kernel.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_kernel.ld
@@ -16,16 +16,45 @@
 
 OUTPUT_FORMAT("binary")
 ENTRY(START)
-kram = 0x00001000;
-phys = 0x00F00000;      /* "high" address for pos-ind. init   */
+
+ram  = 0x00001000;          /* start of user memory                     */
+init = 0x01028000;          /* "pretend" high address for pos-ind. init	*/
+
 MEMORY
 {
-  INIT : org = phys, l = 0xBEFFF   /* init -> top of ram (767KB) */ 
-  KRAM : org = kram, l = 0xFEFFF   /* Allow located code to use all of RAM > 4k */
+  INIT : org = init, l = 0x00010000     /* 64K for init (reused)        */ 
+  RAM  : org = ram,  l = 0x00FFEFFF     /* program can use all RAM > 4K */
 }
 
-PROVIDE(_STACK_TOP   = 0x00100000);   /* default stack at 1MB base RAM top  */
-PROVIDE(_MFP_VECBASE = 0x00000040);   /* handy vector base, useable from C  */
+/* program configuration symbols that may be useful to override */
+/* using linker option: --defsym=<symbol_name>=<value>          */
+PROVIDE(_RAM_SIZE     = 1M);            /* default to 1MB of RAM        */
+PROVIDE(_STACK_TOP    = _RAM_SIZE);     /* default stack at top of RAM  */
+PROVIDE(_STACK_SIZE   = 0x00004000);    /* 16KB default stack size      */
+PROVIDE(_HEAP_END     = _STACK_TOP - _STACK_SIZE); /* heap end at stack */
+
+/* firware absolute addresses (generally not useful to override)  */
+PROVIDE(_MFP_VECTORS    = 0x00000100);  /* MFP interrupt vector base    */
+PROVIDE(_TIMER_100HZ    = 0x0000040C);  /* firmware 100Hz timer counter */
+PROVIDE(_EASY68K_ECHOON = 0x00000410);  /* Easy68k 'echo on' flag       */
+PROVIDE(_EASY68K_PROMPT = 0x00000411);  /* Easy68k 'prompt on' flag     */
+PROVIDE(_EASY68K_SHOWLF = 0x00000412);  /* Easy68k 'LF display' flag    */
+
+PROVIDE(_EFP_TABLE      = 0x00000420);  /* Extension function ptr table */
+
+PROVIDE(_EFP_PRINT      = 0x00000420);  /* Print string to console      */
+PROVIDE(_EFP_PRINTLN    = 0x00000424);  /* Print string with CR+LF      */
+PROVIDE(_EFP_PRINTCHAR  = 0x00000428);  /* Print a character            */
+PROVIDE(_EFP_HALT       = 0x0000042C);  /* Disable interrupts and halt  */
+PROVIDE(_EFP_SENDCHAR   = 0x00000430);  /* Send a character via UART    */
+PROVIDE(_EFP_RECVCHAR   = 0x00000434);  /* Receive a character via UART */
+PROVIDE(_EFP_CLRSCR     = 0x00000438);  /* Clear screen (optional)      */
+PROVIDE(_EFP_MOVEXY     = 0x0000043C);  /* Set cursor position (opt.)   */
+PROVIDE(_EFP_SETCURSOR  = 0x00000440);  /* Enbable/disable cursor (opt.)*/
+
+/* ROM absolute addresses */
+PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
+
 SECTIONS
 {
   .text.init : AT(0)
@@ -38,9 +67,9 @@ SECTIONS
   .text.postinit : AT(SIZEOF(.text.init))
   {
     _postinit = .;
-    KEEP(*(.postinit))  /* KEEP() needed to "anchor" kmain reference for gc-sections */
+    KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
     _postinit_end = .;
-  } > KRAM
+  } > RAM
 
   .text ALIGN(4) :
   {
@@ -48,14 +77,14 @@ SECTIONS
     *(.text*)
     *(.rodata*)
     _code_end = .;
-  } > KRAM
+  } > RAM
   
   .data ALIGN(4) :
   {
     _data_start = .;
     *(.data*)
     _data_end = .;
-  } > KRAM
+  } > RAM
 
   .bss ALIGN(4) :
   {
@@ -63,7 +92,7 @@ SECTIONS
     *(.bss*)
     *(COMMON)
     _bss_end = .;
-  } > KRAM
+  } > RAM
 
   _end = .;
 }

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -18,7 +18,7 @@ OUTPUT_FORMAT("binary")
 ENTRY(START)
 
 ram  = 0x00001000;          /* start of user memory                     */
-init = 0x01028000;          /* "pretend" high address for pos-ind. init	*/
+init = 0x01028000;          /* "pretend" high address for pos-ind. init */
 
 MEMORY
 {

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -16,16 +16,45 @@
 
 OUTPUT_FORMAT("binary")
 ENTRY(START)
-kram = 0x00001000;
-phys = 0x00F00000;      /* "high" address for pos-ind. init   */
+
+ram  = 0x00001000;          /* start of user memory                     */
+init = 0x01028000;          /* "pretend" high address for pos-ind. init	*/
+
 MEMORY
 {
-  INIT : org = phys, l = 0xBEFFF   /* init -> top of ram (767KB) */ 
-  KRAM : org = kram, l = 0xFEFFF   /* Allow located code to use all of RAM > 4k */
+  INIT : org = init, l = 0x00010000     /* 64K for init (reused)        */ 
+  RAM  : org = ram,  l = 0x00FFEFFF     /* program can use all RAM > 4K */
 }
 
-PROVIDE(_STACK_TOP   = 0x00100000);  /* default stack at 1MB base RAM top */
-PROVIDE(_MFP_VECBASE = 0x00000040);  /* handy vector base, useable from C */
+/* program configuration symbols that may be useful to override */
+/* using linker option: --defsym=<symbol_name>=<value>          */
+PROVIDE(_RAM_SIZE     = 1M);            /* default to 1MB of RAM        */
+PROVIDE(_STACK_TOP    = _RAM_SIZE);     /* default stack at top of RAM  */
+PROVIDE(_STACK_SIZE   = 0x00004000);    /* 16KB default stack size      */
+PROVIDE(_HEAP_END     = _STACK_TOP - _STACK_SIZE); /* heap end at stack */
+
+/* firware absolute addresses (generally not useful to override)  */
+PROVIDE(_MFP_VECTORS    = 0x00000100);  /* MFP interrupt vector base    */
+PROVIDE(_TIMER_100HZ    = 0x0000040C);  /* firmware 100Hz timer counter */
+PROVIDE(_EASY68K_ECHOON = 0x00000410);  /* Easy68k 'echo on' flag       */
+PROVIDE(_EASY68K_PROMPT = 0x00000411);  /* Easy68k 'prompt on' flag     */
+PROVIDE(_EASY68K_SHOWLF = 0x00000412);  /* Easy68k 'LF display' flag    */
+
+PROVIDE(_EFP_TABLE      = 0x00000420);  /* Extension function ptr table */
+
+PROVIDE(_EFP_PRINT      = 0x00000420);  /* Print string to console      */
+PROVIDE(_EFP_PRINTLN    = 0x00000424);  /* Print string with CR+LF      */
+PROVIDE(_EFP_PRINTCHAR  = 0x00000428);  /* Print a character            */
+PROVIDE(_EFP_HALT       = 0x0000042C);  /* Disable interrupts and halt  */
+PROVIDE(_EFP_SENDCHAR   = 0x00000430);  /* Send a character via UART    */
+PROVIDE(_EFP_RECVCHAR   = 0x00000434);  /* Receive a character via UART */
+PROVIDE(_EFP_CLRSCR     = 0x00000438);  /* Clear screen (optional)      */
+PROVIDE(_EFP_MOVEXY     = 0x0000043C);  /* Set cursor position (opt.)   */
+PROVIDE(_EFP_SETCURSOR  = 0x00000440);  /* Enbable/disable cursor (opt.)*/
+
+/* ROM absolute addresses */
+PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
+
 SECTIONS
 {
   .text.init : AT(0)
@@ -38,9 +67,9 @@ SECTIONS
   .text.postinit : AT(SIZEOF(.text.init))
   {
     _postinit = .;
-    KEEP(*(.postinit))  /* KEEP() needed to "anchor" kmain reference for gc-sections */
+    KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
     _postinit_end = .;
-  } > KRAM
+  } > RAM
 
   .text ALIGN(4) :
   {
@@ -48,14 +77,18 @@ SECTIONS
     *(.text*)
     *(.rodata*)
     _code_end = .;
-  } > KRAM
+  } > RAM
   
   .data ALIGN(4) :
   {
     _data_start = .;
     *(.data*)
     _data_end = .;
-  } > KRAM
+  } > RAM
+
+  /* verify initialized data ends before load address 0x28000  */
+  ASSERT((_data_end) < 0x28000,
+    "program too large for loader (> 156KiB code+data)")
 
   .bss ALIGN(4) :
   {
@@ -63,7 +96,11 @@ SECTIONS
     *(.bss*)
     *(COMMON)
     _bss_end = .;
-  } > KRAM
+  } > RAM
+
+  /* verify end of program BSS leaves room for mimimum stack size */
+  ASSERT(_bss_end < _HEAP_END,
+    "program too large (use e.g. --defsym=_RAM_SIZE=2M for 2MiB RAM)")
 
   _end = .;
 }

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -1,10 +1,10 @@
 /*
  *------------------------------------------------------------
- *                                  ___ ___ _   
- *  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+ *                                  ___ ___ _
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_
  * |  _| . |_ -|  _| . |     |     | . | . | '_|
- * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
- *                     |_____|       firmware v1                 
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+ *                     |_____|     firmware v1.2
  * ------------------------------------------------------------
  * Copyright (c)2020 Ross Bamford
  * See top-level LICENSE.md for licence information.
@@ -18,11 +18,9 @@ OUTPUT_FORMAT("binary")
 ENTRY(START)
 
 ram  = 0x00001000;          /* start of user memory                     */
-init = 0x01028000;          /* "pretend" high address for pos-ind. init */
 
 MEMORY
 {
-  INIT : org = init, l = 0x00010000     /* 64K for init (reused)        */ 
   RAM  : org = ram,  l = 0x00FFEFFF     /* program can use all RAM > 4K */
 }
 
@@ -40,6 +38,7 @@ PROVIDE(_EASY68K_ECHOON = 0x00000410);  /* Easy68k 'echo on' flag       */
 PROVIDE(_EASY68K_PROMPT = 0x00000411);  /* Easy68k 'prompt on' flag     */
 PROVIDE(_EASY68K_SHOWLF = 0x00000412);  /* Easy68k 'LF display' flag    */
 
+/* NOTE: These need to be kept in sync with firmware equates.S! */
 PROVIDE(_EFP_TABLE      = 0x00000420);  /* Extension function ptr table */
 
 PROVIDE(_EFP_PRINT      = 0x00000420);  /* Print string to console      */
@@ -55,16 +54,20 @@ PROVIDE(_EFP_SETCURSOR  = 0x00000440);  /* Enbable/disable cursor (opt.)*/
 /* ROM absolute addresses */
 PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
 
+/* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
+PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
+PROVIDE(_RUN_ADDRESS    = ORIGIN(RAM)); /* start of user memory         */
+
 SECTIONS
 {
-  .text.init : AT(0)
+  .text.init :
   {
     _init = .;
-    *(.init)
+    KEEP(*(.init))  /* KEEP() "anchors" section for gc-sections */
     _init_end = .;
-  } > INIT
-  
-  .text.postinit : AT(SIZEOF(.text.init))
+  } > RAM
+
+  .text.postinit :
   {
     _postinit = .;
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
@@ -78,17 +81,16 @@ SECTIONS
     *(.rodata*)
     _code_end = .;
   } > RAM
-  
+
   .data ALIGN(4) :
   {
     _data_start = .;
     *(.data*)
+
+    . = ALIGN(4);   /* align for init.S */
+
     _data_end = .;
   } > RAM
-
-  /* verify initialized data ends before load address 0x28000  */
-  ASSERT((_data_end) < 0x28000,
-    "program too large for loader (> 156KiB code+data)")
 
   .bss ALIGN(4) :
   {

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -63,7 +63,7 @@ SECTIONS
   .text.init :
   {
     _init = .;
-    KEEP(*(.init))  /* KEEP() "anchors" section for gc-sections */
+    KEEP(*(.init))      /* KEEP() "anchors" section for gc-sections */
     _init_end = .;
   } > RAM
 
@@ -71,6 +71,7 @@ SECTIONS
   {
     _postinit = .;
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
+    . = ALIGN(4);       /* long align for init.S copying */
     _postinit_end = .;
   } > RAM
 
@@ -86,9 +87,7 @@ SECTIONS
   {
     _data_start = .;
     *(.data*)
-
-    . = ALIGN(4);   /* align for init.S */
-
+    . = ALIGN(4);       /* long align for init.S copying */
     _data_end = .;
   } > RAM
 
@@ -97,6 +96,7 @@ SECTIONS
     _bss_start = .;
     *(.bss*)
     *(COMMON)
+    . = ALIGN(4);       /* long align for kinit clearing */
     _bss_end = .;
   } > RAM
 


### PR DESCRIPTION
Mostly finishes and polishes up some things from previous init changes.  Fix typos and tweak Makefile options.  Add "absolute symbols" from firmware to linker script so they can be used from C (without icky cast or making pointer).  Fixed up symbols for _RAM_SIZE (which also set _STACK_TOP by default) _STACK_SIZE default 16K which is used to make _HEAP_END (useful for malloc),  Also a bunch of others for _MFP_VECTORS (which worked great for removing asm from gpio-interrupts), _TIMER_100HZ and EFP and Easy68K stuff.  Cleaned up gpio-interrupt example to use new features.  Added mcDelaymsec10() to delay based on 100Hz timer.  Added asm sections.