### PR TITLE
Support MC68681 in ROM

### DIFF
--- a/code/firmware/rosco_m68k_v1.1/bootstrap.S
+++ b/code/firmware/rosco_m68k_v1.1/bootstrap.S
@@ -310,26 +310,11 @@ INITDUART:
  
     move.b  #$50,DUART_IVR            ; To further verify, try to set IVR
     move.b  DUART_IVR,D0              ; And then check it was set...
-    move.b  DUART_IVR,D0
     cmp.b   #$50,D0                   ; to 0x50.
     bne.s   .DONE                     ; If not as expected, no DUART...
 
-;    move.b  DUART_IMR,D0              ; Was it written?
-;    beq.s   .CONT1                    ; Appears so...
-
-;    move.b  #0,D5
-;    bra.s   .DONE
-
-.CONT1:
     move.b  #$93,DUART_MR1A           ; (Rx RTS, RxRDY, Char, No parity, 8 bits)
 
- ;   move.b  DUART_IMR,D0              ; Was it written?
- ;   cmp.b   #$93,D0
- ;   beq.s   .CONT2                    ; Appears so...
-
- ;   bra.s   .DONE
-
-.CONT2:
     move.b  #$07,DUART_MR2A           ; (Normal, No TX CTS/RTS, 1 stop bit)
 
     ; 38400
@@ -350,7 +335,7 @@ INITDUART:
     move.b  R_STARTCNTCMD,D0          ; Start count
 
     ; Debug - output clocks on OP2 for scope
-    move.b  #%00000011,DUART_OPCR     ; RxCA (1x) on OP2
+    ; move.b  #%00000011,DUART_OPCR     ; RxCA (1x) on OP2
 
     move.b  #%00000101,DUART_CRA      ; Enable TX/RX
 

--- a/code/firmware/rosco_m68k_v1.1/bootstrap.S
+++ b/code/firmware/rosco_m68k_v1.1/bootstrap.S
@@ -13,6 +13,9 @@
 ; including the UART and system timers, sets up the basic
 ; info in the System Data Block, enables interrupts and 
 ; calls the main stage1 loader (in main1.c).
+;
+; N.B. D5 is used as a global register in this code!
+;      Do not use this register for other things...
 ;------------------------------------------------------------
     include "../../shared/equates.S"
     include "equates.S"
@@ -83,7 +86,8 @@ START::
 
 .ISR_COPY_DONE:
     bsr.w   INITMFP                   ; Initialise MC68901
-    bsr.s   INITSDB                   ; Initialise System Data Block
+    bsr.w   INITDUART                 ; Initialise MC68681
+    bsr.w   INITSDB                   ; Initialise System Data Block
     
     bsr.s   PRINT_BANNER
 
@@ -100,17 +104,20 @@ START::
 ;
 ; Show banner
 ;
+; Must not be called before INITSDB!
+;
 ; Trashes: D0, MFP_UDR
 ; Modifies: A0 (Will point to address after null terminator)
 PRINT_BANNER:
     lea.l   SZ_BANNER0,A0             ; Load first string into A0
+    move.l  EFP_PRINTLN,A3            ; Load function into A3
     
-    bsr.s   EARLY_PRINTLN             ; Print all the banner lines
-    bsr.s   EARLY_PRINTLN             ; This works because EARLY_PRINT
-    bsr.s   EARLY_PRINTLN             ; leaves A0 pointing to the next
-    bsr.s   EARLY_PRINTLN             ; character in memory ;-)
-    bsr.s   EARLY_PRINTLN
-    bsr.s   EARLY_PRINTLN
+    jsr     (A3)                      ; Print all the banner lines
+    jsr     (A3)                      ; This works because EARLY_PRINT
+    jsr     (A3)                      ; leaves A0 pointing to the next
+    jsr     (A3)                      ; character in memory ;-)
+    jsr     (A3)
+    jsr     (A3)
     
     rts                               ; We're done
 
@@ -120,8 +127,8 @@ PRINT_BANNER:
 ; of FW_PRINT (pointed to by the EFP table) and likely replaced later.
 ;
 ; Trashes: D0, MFP_UDR
-; Modifies: A0 (Will point to address after null terminator)
-EARLY_PRINT:
+; Modifies: A0 (Will point to address after null terminator)    
+EARLY_PRINT_MFP:
     move.b  (A0)+,D0                  ; Get next character
     tst.b   D0                        ; Is it null?
     beq.s   .PRINT_DONE               ; ... we're done if so.
@@ -131,10 +138,26 @@ EARLY_PRINT:
     beq.s   .BUFF_WAIT                ; Busywait if not
     
     move.b  D0,MFP_UDR                ; ... otherwise, give character to the MFP
-    bra.s   EARLY_PRINT               ; and loop
+    bra.s   EARLY_PRINT_MFP           ; and loop
 .PRINT_DONE:    
     rts                               ; We're done
     
+
+EARLY_PRINT_DUART:
+    move.b  (A0)+,D0                  ; Get next character
+    tst.b   D0                        ; Is it null?
+    beq.s   .PRINT_DONE               ; ... we're done if so.
+
+.BUFF_WAIT:
+    btst.b  #3,DUART_SRA
+    beq.s   .BUFF_WAIT
+    move.b  D0,DUART_TBA
+    
+    bra.s   EARLY_PRINT_DUART         ; and loop
+.PRINT_DONE:    
+    rts                               ; We're done
+    
+
 ; PRINT null-terminated string pointed to by A0 followed by CRLF.
 ;
 ; Only used directly during early init; Becomes the default implementation
@@ -142,16 +165,28 @@ EARLY_PRINT:
 ;
 ; Trashes: D0, MFP_UDR
 ; Modifies: A0 (Will point to address after null terminator)
-EARLY_PRINTLN:
-    bsr.s   EARLY_PRINT               ; Print callers message
+EARLY_PRINTLN_MFP:
+    bsr.s   EARLY_PRINT_MFP           ; Print callers message
     move.l  A0,-(A7)                  ; Stash A0 to restore later
     
     lea     SZ_CRLF,A0                ; Load CRLF...
-    bsr.s   EARLY_PRINT               ; ... and print it
+    bsr.s   EARLY_PRINT_MFP           ; ... and print it
         
     move.l  (A7)+,A0                  ; Restore A0
     rts
+
+
+EARLY_PRINTLN_DUART:
+    bsr.s   EARLY_PRINT_DUART         ; Print callers message
+    move.l  A0,-(A7)                  ; Stash A0 to restore later
     
+    lea     SZ_CRLF,A0                ; Load CRLF...
+    bsr.s   EARLY_PRINT_DUART         ; ... and print it
+        
+    move.l  (A7)+,A0                  ; Restore A0
+    rts
+
+
 ; Initialise System Data Block
 ;
 INITSDB:
@@ -160,18 +195,23 @@ INITSDB:
     move.w  #50,$408                  ; Heartbeat flash counter at 50 (1 per second)
     move.l  #0,$40C                   ; Zero upticks
 
+    ; Do we have a 68681?
+    tst.b   D5
+    beq.s   .USEMFP
+
+.USEDUART:
     ; Setup default implementations in EFP table.
-    lea     EARLY_PRINT,A0
+    lea     EARLY_PRINT_DUART,A0
     move.l  A0,EFP_PRINT
-    lea     EARLY_PRINTLN,A0
+    lea     EARLY_PRINTLN_DUART,A0
     move.l  A0,EFP_PRINTLN
-    lea     SENDCHAR,A0
+    lea     SENDCHAR_DUART,A0
     move.l  A0,EFP_PRINTCHAR
     lea     HALT,A0
     move.l  A0,EFP_HALT
-    lea     SENDCHAR,A0
+    lea     SENDCHAR_DUART,A0
     move.l  A0,EFP_SENDCHAR
-    lea     RECVCHAR,A0
+    lea     RECVCHAR_DUART,A0
     move.l  A0,EFP_RECVCHAR
     lea     ANSI_MOVEXY,A0
     move.l  A0,EFP_MOVEXY
@@ -179,9 +219,32 @@ INITSDB:
     move.l  A0,EFP_CLRSCR
     lea     .RETURN,A0               ; No-op for default SET CURSOR
     move.l  A0,EFP_SETCURSOR
+
+    bra.s   .RETURN                  ; Done
+
+.USEMFP:
+    ; Setup default implementations in EFP table.
+    lea     EARLY_PRINT_MFP,A0
+    move.l  A0,EFP_PRINT
+    lea     EARLY_PRINTLN_MFP,A0
+    move.l  A0,EFP_PRINTLN
+    lea     SENDCHAR_MFP,A0
+    move.l  A0,EFP_PRINTCHAR
+    lea     HALT,A0
+    move.l  A0,EFP_HALT
+    lea     SENDCHAR_MFP,A0
+    move.l  A0,EFP_SENDCHAR
+    lea     RECVCHAR_MFP,A0
+    move.l  A0,EFP_RECVCHAR
+    lea     ANSI_MOVEXY,A0
+    move.l  A0,EFP_MOVEXY
+    lea     ANSI_CLRSCR,A0
+    move.l  A0,EFP_CLRSCR
+    lea     .RETURN,A0               ; No-op for default SET CURSOR
+    move.l  A0,EFP_SETCURSOR
+
 .RETURN
     rts
-
 
 
 ; Initialise MFP
@@ -221,8 +284,84 @@ INITMFP:
     move.b  #$FE,MFP_GPDR             ; Turn on GPIO #0 (Green LED)
     rts
 
-    
-    
+
+; Initialise MC68681 DUART if present
+;
+; If an MC68681 is found, this will set D5 to 1. Otherwise, D5 will be 0.
+; This is used to signal INITSDB that it should use the DUART vectors instead of
+; the MFP ones.
+INITDUART:
+    move.b  #0,D5                     ; Indicate no MC68681 by default
+
+    move.b  #$0,DUART_IMR             ; Mask all interrupts
+
+    ; See if there appears to be a 68681 in the system...
+    ; 
+    ; IVR is a convenient register that allows both read and write. We'll check its
+    ; initial value is as expected, then set ensure the initial read wasn't
+    ; a fluke. Note that, with the basic 68681 board, vectored interrupts are 
+    ; never used, so setting this has no effect - it's just a test. 
+    ;
+    ; This is hardly definitive, but should be good-enough for our purposes...
+    ;
+    move.b  DUART_IVR,D0              ; Get IVR - Should be 0x0F at reset
+    cmp.b   #$0F,D0
+    bne.s   .DONE                     ; If not as expected, no DUART...
+ 
+    move.b  #$50,DUART_IVR            ; To further verify, try to set IVR
+    move.b  DUART_IVR,D0              ; And then check it was set...
+    move.b  DUART_IVR,D0
+    cmp.b   #$50,D0                   ; to 0x50.
+    bne.s   .DONE                     ; If not as expected, no DUART...
+
+;    move.b  DUART_IMR,D0              ; Was it written?
+;    beq.s   .CONT1                    ; Appears so...
+
+;    move.b  #0,D5
+;    bra.s   .DONE
+
+.CONT1:
+    move.b  #$93,DUART_MR1A           ; (Rx RTS, RxRDY, Char, No parity, 8 bits)
+
+ ;   move.b  DUART_IMR,D0              ; Was it written?
+ ;   cmp.b   #$93,D0
+ ;   beq.s   .CONT2                    ; Appears so...
+
+ ;   bra.s   .DONE
+
+.CONT2:
+    move.b  #$07,DUART_MR2A           ; (Normal, No TX CTS/RTS, 1 stop bit)
+
+    ; 38400
+    ; move.b  #$70,DUART_ACR           ; Set 0, Timer, X1/X2, /16
+    ; move.b  #$CC,DUART_CSRA          ; 38K4
+
+    ; 57600
+    ; move.b  #$60,DUART_ACR           ; Set 0, Counter, X1/X2, /16
+    ; move.b  #$DD,DUART_CSRA          ; Baud from timer
+
+    ; 115200 working
+    move.b  #$60,DUART_ACR            ; Set 0, Counter, X1/X2, /16
+    move.b  DUART_CRA,D0              ; Enable undocumented rates
+    move.b  #$66,DUART_CSRA           ; 1200 per spec, uses counter instead
+
+    move.b  #0,DUART_CUR              ; Counter high: 0
+    move.b  #2,DUART_CLR              ; Counter  low: 2  (115.2KHz)
+    move.b  R_STARTCNTCMD,D0          ; Start count
+
+    ; Debug - output clocks on OP2 for scope
+    move.b  #%00000011,DUART_OPCR     ; RxCA (1x) on OP2
+
+    move.b  #%00000101,DUART_CRA      ; Enable TX/RX
+
+    ; TODO CTS/RTS Not yet working - figure out how to lower RTS!
+    move.b  #$ff,W_OPR_RESETCMD       ; Clear all OP bits (lower RTS)
+    move.b  #0,W_OPR_SETCMD
+
+    move.b  #1,D5                     ; Set D5 to indicate to INITSDB that there's a DUART present...
+ .DONE:
+    rts
+
 ;------------------------------------------------------------
 ; Routines for include/machine.h
 HALT::
@@ -375,11 +514,36 @@ TRAP_HANDLER:
     move.l  #$C001C0DE,$404
     rte
 
+; Convenience SEND/RECV char functions, using the EFP table.
+; These are provided for use by the Easy68k syscalls.S
+;
+; TODO these should be moved to syscalls_asm.S!
+SENDCHAR::
+    move.l  A3,-(A7)
+    move.l  EFP_SENDCHAR,A3
+    jsr     (A3)
+    move.l  (A7)+,A3
+    rts
+
+RECVCHAR::
+    move.l  A3,-(A7)
+    move.l  EFP_RECVCHAR,A3
+    jsr     (A3)
+    move.l  (A7)+,A3
+    rts
+
 ; Send a single character via UART
 ;
 ; Trashes: MFP_UDR
 ; Modifies: Nothing
-SENDCHAR::
+SENDCHAR_DUART:
+    btst.b  #3,DUART_SRA
+    beq.s   SENDCHAR_DUART
+    move.b  D0,DUART_TBA
+    rts
+
+
+SENDCHAR_MFP:
     move.l  D1,-(A7)              ; Save D1
 .BEGIN
     bset.b  #7,MFP_GPDR           ; Raise (inhibit) RTS
@@ -397,7 +561,14 @@ SENDCHAR::
 ;
 ; Trashes: MFP_UDR
 ; Modifies: D0 (return)
-RECVCHAR::
+RECVCHAR_DUART:
+    btst.b  #0,DUART_SRA
+    beq.s   RECVCHAR_DUART
+    move.b  DUART_RBA,D0
+    rts
+
+
+RECVCHAR_MFP:
     bclr.b  #7,MFP_GPDR           ; Lower RTS
 .BEGIN
     move.b  MFP_RSR,D0            ; Get RSR

--- a/code/firmware/rosco_m68k_v1.1/equates.S
+++ b/code/firmware/rosco_m68k_v1.1/equates.S
@@ -29,3 +29,118 @@ EFP_RECVCHAR    equ    $434
 EFP_CLRSCR      equ    $438
 EFP_MOVEXY      equ    $43C
 EFP_SETCURSOR   equ    $440
+
+; Equates for MC68681 DUART
+; ------------------------------------------------------------
+;
+; This assumes the 68681 RS1-RS4 are connected to A1-A4, and that
+; the decoder maps starting at $f80008. In that scheme, this is
+; how IO addresses map to MC68681 registers:
+;
+; Address   :  A23 A22 A21 A20 A19 A18 A17 A16 A15 A14 A13 A12 A11 A10 A9  A8  A7  A6  A5  A4  A3  A2  A1  A0 (4321) = Reg
+; 0x00f80008:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   0   0  (0100) = 4
+; 0x00f8000a:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   1   0  (0101) = 5
+; 0x00f8000c:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   1   0   0  (0110) = 6
+; 0x00f8000e:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   1   1   0  (0111) = 7
+; 0x00f80010:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   0   0   0  (1000) = 8
+; 0x00f80012:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   0   1   0  (1001) = 9
+; 0x00f80014:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   1   0   0  (1010) = 10
+; 0x00f80016:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   1   1   0  (1011) = 11
+; 0x00f80018:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   1   0   0   0  (1100) = 12
+; 0x00f8001a:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   1   0   1   0  (1101) = 13
+; 0x00f8001c:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   1   1   0   0  (1110) = 14
+; 0x00f8001e:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0   1   1   1   1   0  (1111) = 15
+; 0x00f80020:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   0   0   0   0  (0000) = 0
+; 0x00f80022:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   0   0   1   0  (0001) = 1
+; 0x00f80024:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   0   1   0   0  (0010) = 2
+; 0x00f80026:  1   1   1   1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   1   0   0   1   1   0  (0011) = 3
+;
+; For reference to the datasheet, the MC68681 register number is listed below.
+;
+RW_MODE_A       equ     $f80020      ; RW register 0
+
+R_STATUS_A      equ     $f80022      ; R register 1
+W_CLKSEL_A      equ     $f80022      ; W register 1
+
+; R is DO NOT ACCESS
+W_COMMAND_A     equ     $f80024      ; W register 2
+
+R_RXBUF_A       equ     $f80026      ; R register 3
+W_TXBUF_A       equ     $f80026      ; W register 3
+
+;============================
+
+;RW_MODE_A       equ     $f80000      ; RW register 0
+
+;R_STATUS_A      equ     $f80002      ; R register 1
+;W_CLKSEL_A      equ     $f80002      ; W register 1
+
+; R is DO NOT ACCESS
+;W_COMMAND_A     equ     $f80004      ; W register 2
+
+;R_RXBUF_A       equ     $f80006      ; R register 3
+;W_TXBUF_A       equ     $f80006      ; W register 3
+;=============================
+
+R_INPORTCHG     equ     $f80008      ; R register 4
+W_AUXCTLREG     equ     $f80008      ; W register 4
+
+R_ISR           equ     $f8000a      ; R register 5
+W_IMR           equ     $f8000a      ; W register 5
+
+R_COUNTERMSB    equ     $f8000c      ; R register 6
+W_COUNTUPPER    equ     $f8000c      ; W register 6
+
+R_COUNTERLSB    equ     $f8000e      ; R register 7
+W_COUNTLOWER    equ     $f8000e      ; W register 7
+
+RW_MODE_B       equ     $f80010      ; RW register 8
+
+R_STATUS_B      equ     $f80012      ; R register 9
+W_CLKSEL_B      equ     $f80012      ; W register 9
+
+; R is DO NOT ACCESS
+W_COMMAND_B     equ     $f80014      ; W register 10
+
+R_RXBUF_B       equ     $f80016      ; R register 11
+W_TXBUF_B       equ     $f80016      ; W register 11
+
+RW_IVR          equ     $f80018      ; RW register 12
+
+R_INPUTPORT     equ     $f8001a      ; R register 13
+W_OUTPORTCFG    equ     $f8001a      ; W register 13
+
+R_STARTCNTCMD   equ     $f8001c      ; R register 14
+W_OPR_SETCMD    equ     $f8001c      ; W register 14
+
+R_STOPCNTCMD    equ     $f8001e      ; R register 15
+W_OPR_RESETCMD  equ     $f8001e      ; W register 15
+
+; For convenience, also define the mnemonics used in the datasheet...
+;
+; These are *not* defined (by the datasheet) for all registers!
+;
+DUART_MR1A      equ     RW_MODE_A
+DUART_MR2A      equ     RW_MODE_A
+DUART_SRA       equ     R_STATUS_A
+DUART_CSRA      equ     W_CLKSEL_A
+DUART_CRA       equ     W_COMMAND_A
+DUART_RBA       equ     R_RXBUF_A
+DUART_TBA       equ     W_TXBUF_A
+DUART_IPCR      equ     R_INPORTCHG
+DUART_ACR       equ     W_AUXCTLREG
+DUART_ISR       equ     R_ISR
+DUART_IMR       equ     W_IMR
+DUART_CUR       equ     R_COUNTERMSB
+DUART_CTUR      equ     W_COUNTUPPER
+DUART_CLR       equ     R_COUNTERLSB
+DUART_CTLR      equ     W_COUNTLOWER
+DUART_MR1B      equ     RW_MODE_B
+DUART_MR2B      equ     RW_MODE_B
+DUART_SRB       equ     R_STATUS_B
+DUART_CSRB      equ     W_CLKSEL_B
+DUART_CRB       equ     W_COMMAND_B
+DUART_RBB       equ     R_RXBUF_B
+DUART_TBB       equ     W_TXBUF_B
+DUART_IVR       equ     RW_IVR
+DUART_OPCR      equ     W_OUTPORTCFG

--- a/code/firmware/rosco_m68k_v1.1/stage2/kermit/include/platform.h
+++ b/code/firmware/rosco_m68k_v1.1/stage2/kermit/include/platform.h
@@ -15,7 +15,7 @@
 
 
 #ifndef IBUFLEN
-#define IBUFLEN  2048			/* File input buffer size */
+#define IBUFLEN  8192			/* File input buffer size */
 #endif /* IBUFLEN */
 
 #ifndef OBUFLEN


### PR DESCRIPTION
Adds fairly-transparent support for the MC68681 into ROM, when mapped into the space used by the (forthcoming) MC68681 expansion board. This change is initially going into ROM 1.1 (and then that release will be frozen) before being pushed into 1.2 and finally develop.