### PR TITLE
Add debug_stub debug exception handler

### DIFF
--- a/code/software/libs/Makefile
+++ b/code/software/libs/Makefile
@@ -35,12 +35,16 @@ include src/cstdlib/include.mk
 include src/printf/include.mk
 include src/easy68k/include.mk
 include src/rtlsupport/include.mk
+include src/debug_stub/include.mk
 include src/start_serial/include.mk
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $<
 
 %.o : %.S
+	$(AS) $(ASFLAGS) -o $@ $<
+
+%.o : %.asm
 	$(AS) $(ASFLAGS) -o $@ $<
 
 .PHONY: all install clean clobber

--- a/code/software/libs/src/debug_stub/debug_stub.asm
+++ b/code/software/libs/src/debug_stub/debug_stub.asm
@@ -1,0 +1,226 @@
+;
+; vim: set et ts=8 sw=8
+;------------------------------------------------------------
+;                                  ___ ___ _
+;  ___ ___ ___ ___ ___       _____|  _| . | |_
+; |  _| . |_ -|  _| . |     |     | . | . | '_|
+; |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+;                     |_____|
+; ------------------------------------------------------------
+; Copyright (c) 2020 Xark
+; MIT License
+; ------------------------------------------------------------
+
+; This adds a small (under 1 KiB) inline asm 680x0 exception handler so if an
+; exception occurs (i.e., a crash) it will print the CPU PC address where the
+; exception occurred along with registers.  Often with just the PC crash
+; address the code causing the you can located with e.g:
+;
+; m68k-elf-addr2line -e myprogram.elf 0x1234
+;
+; This will often give a line "near" the problem, but is still very helpful.
+;
+; You can also look for the PC crash address in the ".dis" disassembly, which
+; if debug information is enabled will show the source with corresponding asm
+; code (and match up PC crash address).
+;
+; TO USE: Link with program -ldebug_stub, #include <debug_stub.h> and call
+; debug_stub() at program startup.  This will install the exception handlers
+; (with no other noticiable effect).  After this, a program crash will invoke
+; a debug_stub exceptions handlers which will print CPU state at the time of
+; the crash on the default UART, and then warm-reset back to the loader.
+
+                include "../../shared/equates.S"
+
+                section .text.debug_stub,text
+                align  2
+debug_stub::
+                moveq.l #10,d0
+                lea.l   8.w,a1
+                lea.l   .buserr_hdlr(pc),a0
+.setvecloop     move.l  a0,(a1)+
+                add.l   #.addrerr_hdlr-.buserr_hdlr,a0
+                subq.l  #1,d0
+                bne     .setvecloop
+                rts
+
+.buserr_str     dc.b    "Bus error",0
+.addrerr_str    dc.b    "Address error",0
+.illegal_str    dc.b    "Illegal instruction",0
+.divzero_str    dc.b    "Division by zero",0
+.chkinst_str    dc.b    "CHK instruction",0
+.trapinst_str   dc.b    "TRAPV instruction",0
+.privil_str     dc.b    "Privilege violation",0
+.trace_str      dc.b    "Trace",0
+.Ainstr_str     dc.b    "$Axxx instruction",0
+.Finstr_str     dc.b    "$Fxxx instruction",0
+
+.exintro_str    dc.b    13,10,7,"*** 🤯 m68k: ",0
+.exfa_str       dc.b    " (fault addr ",0
+.exfa2_str      dc.b    ")",0
+.expc_str       dc.b    13,10,"PC=",0
+.exop_str       dc.b    " op=",0
+.exsr_str       dc.b    "     SR=",0
+.exus_str       dc.b    "    USP=",0
+.crlf_str       dc.b    13,10,0
+
+                align   2
+; NOTE: These handlers targets must all be the exact same size
+.buserr_hdlr    or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #0<<1,d2
+                bra.b   .debug_dump
+.addrerr_hdlr   or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #1<<1,d2
+                bra.b   .debug_dump
+.illegal_hdlr   or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #2<<1,d2
+                bra.b   .debug_dump
+.divzero_hdlr   or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #3<<1,d2
+                bra.b   .debug_dump
+.chkinst_hdlr   or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #4<<1,d2
+                bra.b   .debug_dump
+.trapinst_hdlr  or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #5<<1,d2
+                bra.b   .debug_dump
+.privil_hdlr    or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #6<<1,d2
+                bra.b   .debug_dump
+.trace_hdlr     or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #7<<1,d2
+                bra.b   .debug_dump
+.Ainstr_hdlr    or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #8<<1,d2
+                bra.b   .debug_dump
+.Finstr_hdlr    or.w    #$0700,sr
+                movem.l d0-d7/a0-a7,-(sp)
+                moveq.l #9<<1,d2
+
+        ; double check above sizes all match
+        if      (.Finstr_hdlr-.buserr_hdlr)!=(.addrerr_hdlr-.buserr_hdlr)*9
+                fail    "exception handler target size mismatch"
+        endif
+
+.debug_dump     move.w  16<<2(sp),ex_sr
+                move.l  16<<2+2(sp),a0
+                move.l  a0,ex_pc
+                move.w  (a0),ex_opcode
+                clr.l   ex_fault
+                cmp.w   #2<<1,d2        ; fault for addr & bus error only
+                bge     .nofault
+                move.l  16<<2+10(sp),ex_fault
+                bra     .nofault
+
+; NOTE: Table placed here so byte displacement branches above can reach
+.except_strtbl  dc.w    .buserr_str-.except_strtbl
+                dc.w    .addrerr_str-.except_strtbl
+                dc.w    .illegal_str-.except_strtbl
+                dc.w    .divzero_str-.except_strtbl
+                dc.w    .chkinst_str-.except_strtbl
+                dc.w    .trapinst_str-.except_strtbl
+                dc.w    .privil_str-.except_strtbl
+                dc.w    .trace_str-.except_strtbl
+                dc.w    .Ainstr_str-.except_strtbl
+                dc.w    .Finstr_str-.except_strtbl
+
+.nofault        move.l  _EFP_PRINT.w,a1
+                lea.l   .exintro_str(pc),a0
+                jsr     (a1)                    ; print exception name
+                move.w	.except_strtbl(pc,d2.w),d0
+                lea.l   .except_strtbl(pc,d0.w),a0
+                jsr     (a1)
+                move.l  ex_fault,d2
+                beq     .nofault2
+                lea.l   .exfa_str(pc),a0
+                jsr     (a1)
+                bsr     printhex                ; print fault address (if any)
+                lea.l   .exfa2_str(pc),a0
+                jsr     (a1)
+.nofault2       lea.l   .expc_str(pc),a0
+                jsr     (a1)
+                move.l  ex_pc,d2
+                bsr     printhex                ; print PC
+                lea.l   .exop_str(pc),a0
+                jsr     (a1)
+                move.l  ex_pc,a0
+                move.l  (a0),d2                 ; into upper word
+                moveq.l #4,d3                   ; 4 digits
+                bsr     printhex_n              ; print opcode
+                lea.l   .exsr_str(pc),a0
+                jsr     (a1)
+                move.l  ex_sr,d2                ; into upper word
+                moveq.l #4,d3                   ; 4 digits
+                bsr     printhex_n              ; print SR
+                lea.l   .exus_str(pc),a0
+                jsr     (a1)
+                move.l  usp,a0
+                move.l  a0,d2
+                bsr     printhex                ; print USP
+                lea.l   .crlf_str(pc),a0
+                jsr     (a1)
+                moveq.l #0,d4                   ; register counter (a reg >= 8)
+                move.l  _EFP_PRINTCHAR.w,a0
+                move.l  a7,a2
+.regloop        moveq.l #"d",d0
+                cmp.b   #8,d4
+                blt     .notareg
+                moveq.l #"a",d0
+.notareg        jsr     (a0)                    ; print "d" or "a"
+                move.l  d4,d0
+                and.b   #7,d0
+                bsr     hexdigit
+                jsr     (a0)                    ; print register number
+                moveq.l #"=",d0
+                jsr     (a0)
+                move.l  (a2)+,d2
+                bsr     printhex
+                addq.l  #1,d4
+                move.b  d4,d0
+                and.b   #3,d0
+                beq     .preol
+                moveq.l #" ",d0
+                jsr     (a0)
+                bra     .regloop
+.preol          moveq.l #13,d0
+                jsr     (a0)
+                moveq.l #10,d0
+                jsr     (a0)
+                cmp.b   #16,d4
+                blt     .regloop
+                move.l  4.w,a0
+                jmp     (a0)
+
+; prints hex number, enter with d2.l, alters a0, d0, d2 & d3
+printhex        moveq.l #8,d3
+printhex_n      move.l  _EFP_PRINTCHAR.w,a0
+.hexloop        rol.l   #4,d2
+                move.b  d2,d0
+                and.w   #$F,d0
+                bsr     hexdigit
+                jsr     (a0)
+                subq.b  #1,d3
+                bne     .hexloop
+                rts
+hexdigit        cmp.b   #10,d0
+                blt     .notalpha
+                addq.b  #7,d0
+.notalpha       add.w   #"0",d0
+                rts
+
+                section .bss._debug_stub,bss
+                align  2
+
+ex_sr           ds.w    1
+ex_opcode       ds.w    1
+ex_pc           ds.l    1
+ex_fault        ds.l    1

--- a/code/software/libs/src/debug_stub/debug_stub.asm
+++ b/code/software/libs/src/debug_stub/debug_stub.asm
@@ -11,14 +11,16 @@
 ; MIT License
 ; ------------------------------------------------------------
 
-; This adds a small (under 1 KiB) inline asm 680x0 exception handler so if an
-; exception occurs (i.e., a crash) it will print the CPU PC address where the
-; exception occurred along with registers.  Often with just the PC crash
-; address the code causing the you can located with e.g:
+; This adds a small (under 1 KiB) 680x0 exception handler stub so that if a
+; CPU exception occurs (i.e., a crash) it will print the CPU PC address where
+; the exception occurred along with registers on the default output device.
+; Often with just the PC crash address you can narrow down the source code
+; causing the problem with e.g:
 ;
 ; m68k-elf-addr2line -e myprogram.elf 0x1234
 ;
-; This will often give a line "near" the problem, but is still very helpful.
+; This will often give a line "near" the problem (usually after the actual
+; cause), but is still very helpful.
 ;
 ; You can also look for the PC crash address in the ".dis" disassembly, which
 ; if debug information is enabled will show the source with corresponding asm
@@ -26,9 +28,9 @@
 ;
 ; TO USE: Link with program -ldebug_stub, #include <debug_stub.h> and call
 ; debug_stub() at program startup.  This will install the exception handlers
-; (with no other noticiable effect).  After this, a program crash will invoke
-; a debug_stub exceptions handlers which will print CPU state at the time of
-; the crash on the default UART, and then warm-reset back to the loader.
+; (with no other noticeable effect).  After this, a program crash will invoke
+; a debug_stub exception handler which will print CPU state at the time of the
+; crash on the default output device, and then warm-reset back to the loader.
 
                 include "../../shared/equates.S"
 

--- a/code/software/libs/src/debug_stub/include.mk
+++ b/code/software/libs/src/debug_stub/include.mk
@@ -1,0 +1,16 @@
+LIB=debug_stub
+LIBOBJECTS=$(DIR)/debug_stub.o
+LIBINCLUDES=$(DIR)/include
+
+# ---===---
+DIR := $(shell dirname $(lastword $(MAKEFILE_LIST)))
+UPPERLIB := $(shell echo $(LIB) | tr '[:lower:]' '[:upper:]')
+BINARY := lib$(LIB).a
+CFLAGS  := $(CFLAGS) -I$(LIBINCLUDES) -DBUILD_ROSCOM68K_$(UPPERLIB)_LIB
+OBJECTS := $(OBJECTS) $(LIBOBJECTS)
+INCLUDES := $(INCLUDES) $(DIR)/include/*
+LIBS := $(LIBS) $(DIR)/$(BINARY)
+
+$(DIR)/$(BINARY): $(LIBOBJECTS)
+	$(AR)	$(ARFLAGS) rs $@ $^
+	$(RANLIB) $@

--- a/code/software/libs/src/debug_stub/include/debug_stub.h
+++ b/code/software/libs/src/debug_stub/include/debug_stub.h
@@ -11,13 +11,13 @@
  * ------------------------------------------------------------
  * Copyright (c) 2020 Xark MIT License
  *
- * Debug stub to catch CPU exception to aid debugging.
+ * Debug stub to catch CPU exceptions to aid debugging.
  *
  * USE:  Include this header, call debug_stub() at program startup and link
- * your program with -ldebug_stub.  After that, CPU exceptions will be caught
- * and instead of the default rosco_m68k red LED blink code, CPU state
- * information will be printed to the default UART and the program will
- * warm-reset back to the loader.
+ * your program with -ldebug_stub.  After that, CPU exceptions (i.e., program
+ * crashes) will be caught and instead of the default rosco_m68k red LED blink
+ * code, CPU state information will be printed to the default output device
+ * and the program will warm-reset back to the loader.
  *
  * As an example, an "address error" exception might look like this:
  * 
@@ -37,14 +37,18 @@
  * of the exception.
  *
  * If you have a rosco_m68k elf file, generated with debug information (-g)
- * then you can usually get the C source line of the exception (or close to
- * it, often the line after) using m68k-elf-addr2line, the "-e" option
- * followed by your program elf file and the PC address from the debug
- * information printed on the UART (preceeded with "0x" for hex).  For
- * example, for the crash above:
+ * then you can usually get the C source line of the code that caused the
+ * exception (or close to it, often the line after) using m68k-elf-addr2line,
+ * the "-e" option followed by your program elf file and the PC address from
+ * the debug information printed (preceeded with "0x" for hex).  For example,
+ * for the crash above:
  *
  * m68k-elf-addr2line -e example.elf 0x115A
  *
+ * NOTE: On 68010/12 CPUs the PC counter (and "op") may be up to five words
+ * ahead of the actual location where the exception occurred on a bus or
+ * address error (due to additional prefetch mechanisms in those CPUs).
+ * However, the "fault addr" should remain accurate.
  * ------------------------------------------------------------
  */
 #ifndef _ROSCOM68K_DEBUGSTUB_H

--- a/code/software/libs/src/debug_stub/include/debug_stub.h
+++ b/code/software/libs/src/debug_stub/include/debug_stub.h
@@ -1,0 +1,56 @@
+/*
+ *-------------------------------------------------------------
+ *                                  ___ ___ _
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+ *                     |_____|       firmware v1
+*/
+
+/*
+ * ------------------------------------------------------------
+ * Copyright (c) 2020 Xark MIT License
+ *
+ * Debug stub to catch CPU exception to aid debugging.
+ *
+ * USE:  Include this header, call debug_stub() at program startup and link
+ * your program with -ldebug_stub.  After that, CPU exceptions will be caught
+ * and instead of the default rosco_m68k red LED blink code, CPU state
+ * information will be printed to the default UART and the program will
+ * warm-reset back to the loader.
+ *
+ * As an example, an "address error" exception might look like this:
+ * 
+ * *** 🤯 m68k: Address error (fault addr 1BADADD1)
+ * PC=0000115A op=001C     SR=2004    USP=FFFFFFFF
+ * d0=00000000 d1=00000001 d2=000FFF8E d3=00000000
+ * d4=00000010 d5=FFFFFFFF d6=FFFFFFFF d7=FFFFFFFF
+ * a0=000016FC a1=00000030 a2=000012DE a3=000012CC
+ * a4=0000152A a5=000012F0 a6=000FFF42 a7=000FFF8E
+ *
+ * NOTE: On 68000 CPUs (vs 68010+) the fault addr and PC will be reversed!
+ * "fault addr" is the faulting address (only for bus or address error)
+ * "PC" is the program counter address where the excpetion occurred
+ * "USP" is the user stack pointer (not normally used on "bare" rosco)
+ * "op" is the opcode executing when the excpetion occurred (word at PC)
+ * The rest are all the normal 68k CPU registers contents at the time
+ * of the exception.
+ *
+ * If you have a rosco_m68k elf file, generated with debug information (-g)
+ * then you can usually get the C source line of the exception (or close to
+ * it, often the line after) using m68k-elf-addr2line, the "-e" option
+ * followed by your program elf file and the PC address from the debug
+ * information printed on the UART (preceeded with "0x" for hex).  For
+ * example, for the crash above:
+ *
+ * m68k-elf-addr2line -e example.elf 0x115A
+ *
+ * ------------------------------------------------------------
+ */
+#ifndef _ROSCOM68K_DEBUGSTUB_H
+#define _ROSCOM68K_DEBUGSTUB_H
+
+void debug_stub();  // initialize debug exception handlers in debug_stub.a
+
+#endif
+


### PR DESCRIPTION
This is my first pass at a small debug_stub exception handler (well under 1 KiB).  It has been working great for me and I verified that all exceptions work as expected (except bus error, not sure I can generate one on my board) and I believe all the information presented is accurate.  My thinking is this could be very handy in ROM (especially if a full debugger can't fit), but even linked in I am finding it extremely useful.