### PR TITLE
Fix #114

### DIFF
--- a/code/software/ehbasic/Makefile
+++ b/code/software/ehbasic/Makefile
@@ -4,7 +4,7 @@
 # See LICENSE
 
 DEFINES=-DROSCO_M68K
-ASFLAGS=-Fbin -m68010 -quiet $(DEFINES)
+ASFLAGS=-Fbin -m68010 -quiet -nowarn=2028 $(DEFINES)
 AS=vasmm68k_mot
 RM=rm -f
 
@@ -19,7 +19,7 @@ LST=$(BINARY_BASENAME).lst
 BINARY=$(BINARY_BASENAME).$(BINARY_EXT)
 
 ifeq ($(MC68681),true)
-DEFINES:=$(DEFINES) -DMC68681 -quiet -nowarn=2028
+DEFINES:=$(DEFINES) -DMC68681 
 endif
 
 $(BINARY) : ehbasic.S ehdefs.S

--- a/code/software/ehbasic/Makefile
+++ b/code/software/ehbasic/Makefile
@@ -18,8 +18,12 @@ BINARY_EXT=bin
 LST=$(BINARY_BASENAME).lst
 BINARY=$(BINARY_BASENAME).$(BINARY_EXT)
 
+ifeq ($(MC68681),true)
+DEFINES:=$(DEFINES) -DMC68681 -quiet -nowarn=2028
+endif
+
 $(BINARY) : ehbasic.S ehdefs.S
-	vasmm68k_mot -quiet -Fbin -m68010 -nowarn=2028 -L $(LST) -o $(BINARY) ehbasic.S
+	vasmm68k_mot $(ASFLAGS) -L $(LST) -o $(BINARY) ehbasic.S
 	chmod a-x $@
 
 .PHONY: all clean load

--- a/code/software/ehbasic/README.md
+++ b/code/software/ehbasic/README.md
@@ -3,23 +3,34 @@
 This is a port of Lee Davison's Enhanced Basic for 680x0 to the rosco_m68k.
 
 It can be loaded into RAM (by the serial bootloader) where it will currently run
-directly from $28000 (i.e. it does not relocate low like most of the other software
-does, because of some idiosyncracies in the way its memory is laid out - this is 
-likely to change in the future). BASIC RAM is kept below this and comprises 128K 
-at the moment.
+directly from the load address (i.e. it does not relocate low like most of the 
+other software does, because of some idiosyncracies in the way its memory is laid
+out - this is likely to change in the future). BASIC RAM is kept below this and 
+comprises 128K at the moment.
 
 It should also support being built into a ROM, though this is as-yet untested.
 
 Note that EhBASIC, like any good BASIC, is case-sensitive! Commands must be in
 uppercase, or you will receive an error message.
 
-Just run `make` to build, with the standard toolchain.
-
 References:
 
 1. http://retro.hansotten.nl/home/lee-davison-web-site/
 2. http://www.easy68k.com/applications.htm
 3. http://sun.hasenbraten.de/vasm/
+
+## Building
+
+### Standard board (No MC68681 Dual UART expansion)
+
+Just run `make` to build, with the standard toolchain.
+
+### With MC68681 Dual UART expansion board
+
+To work with the MC68681 expansion, you must pass `MC68681=true` to the make
+command:
+
+`MC68681=true make clean all`
 
 ------------------------------------------------------------------------
 

--- a/code/software/ehbasic/ehbasic.S
+++ b/code/software/ehbasic/ehbasic.S
@@ -76,7 +76,6 @@ nobrk		EQU	0				* null response to INPUT causes a break
   ORG		$28000			* past the vectors in a real system
 
          BRA    code_start       * For convenience, so you can start from first address
-
 *************************************************************************************
 *
 * the following code is rosco_m68k-specific
@@ -95,7 +94,29 @@ VEC_OUT:
 * input a character from the console into register d0
 * else return Cb=0 if there's no character available
 
+DUART_SRA      equ     $f80022      ; R register 1
+DUART_RBA      equ     $f80026      ; R register 3
+
 VEC_IN:
+    ifd MC68681
+
+; MC68681 version
+
+    move.b  DUART_SRA,D0          ; Check DUART status reg A
+    btst    #0,D0                 ; Bit 0
+    bne.s   .GOTCHR               ; Notready if zero
+    andi.b  #$FE,CCR              ; Else clear the carry flag, no character available
+    rts                           ; And return
+    
+.GOTCHR
+    move.b  DUART_RBA,D0
+    ori.b   #1,CCR                ; ... and set the carry to flag to indicate we got a char
+    rts
+
+    else
+
+; MFP UART version
+
     move.b  MFP_RSR,D0            ; Get RSR
     btst    #7,D0                 ; Is buffer_full bit set?
     bne.s   .GOTCHR               ; Yes - Go to receive character
@@ -114,6 +135,8 @@ VEC_IN:
     move.b  MFP_UDR,D0            ; Get the data
     ori.b   #1,CCR                ; Set the carry to flag we got a char
     rts
+    
+    endif
 
 *************************************************************************************
 *
@@ -133,11 +156,8 @@ VEC_SV
 
 *************************************************************************************
 *
-* turn off simulator key echo
-
 code_start
 kmain::
-
 * Display cursor
   move.l  #5,D1
   move.l  #1,D0


### PR DESCRIPTION
Not an ideal fix, but better than nothing. 

Supports 68681 via a Makefile flag (and conditional assembly). This turned out to be preferable to trying to detect a 68681 in the code. This _could have_ been better if CHECKCHAR was in the EFP table, but even once that is, this would still need to work on existing 1.1 and 1.2 ROMS...