### PR TITLE
Update header files to correct build errors.

### DIFF
--- a/code/software/libs/src/libm/common/math_err.c
+++ b/code/software/libs/src/libm/common/math_err.c
@@ -30,7 +30,12 @@
 
 #if WANT_ERRNO
 #include <errno.h>
-extern int *__errno(void);
+
+   int err = 1;
+   int *__errno()
+   {
+      return &err;
+   }
 /* NOINLINE reduces code size and avoids making math functions non-leaf
    when the error handling is inlined.  */
 NOINLINE static double

--- a/code/software/libs/src/libm/common/math_err.c
+++ b/code/software/libs/src/libm/common/math_err.c
@@ -30,6 +30,7 @@
 
 #if WANT_ERRNO
 #include <errno.h>
+extern int *__errno(void);
 /* NOINLINE reduces code size and avoids making math functions non-leaf
    when the error handling is inlined.  */
 NOINLINE static double

--- a/code/software/libs/src/libm/include/fdlibm.h
+++ b/code/software/libs/src/libm/include/fdlibm.h
@@ -10,12 +10,16 @@
  * is preserved.
  * ====================================================
  */
+#ifndef _ROSCOM68K_FDMLIB_H
+#define _ROSCOM68K_FDMLIB_H
 
 /* REDHAT LOCAL: Include files.  */
 #include <math.h>
 #include <sys/types.h>
 #include <machine/ieeefp.h>
 #include "math_config.h"
+
+extern int *__errno(void);
 
 extern int finite (double);
 extern int finitef (float);
@@ -433,8 +437,4 @@ typedef union {
 
 #endif  /* _COMPLEX_H */
 
-int err = 1;
-int *__errno()
-{
-return &err;
-}
+#endif

--- a/code/software/libs/src/libm/include/sys/errno.h
+++ b/code/software/libs/src/libm/include/sys/errno.h
@@ -14,7 +14,6 @@ extern "C" {
 #define errno (*__errno())
 #endif
 
-extern int *__errno(void);
 
 /* Please don't use these variables directly.
    Use strerror instead. */


### PR DESCRIPTION
Libm header file changes to ensure correct compile of test program

```
libm-test mpe18$ make clean
rm -f kmain.o libm_test.bin   libm_test.map
libm-test mpe18$ make all
m68k-elf-gcc -c -std=c11 -ffreestanding -Wall -pedantic -Werror -I../libs/build/include -mcpu=68010 -march=68010 -mtune=68010 -mno-align-int -mno-strict-align -msoft-float -DROSCO_M68K  -o kmain.o kmain.c
m68k-elf-ld -T ../libs/build/lib/ld/serial/rosco_m68k_program.ld -L ../libs/build/lib -Map=libm_test.map -L/usr/local/Cellar/gcc-cross-m68k@10/10.2.0/lib/gcc/m68k-elf/10.2.0/m68000/ -L/usr/local/Cellar/gcc-cross-m68k@10/10.2.0/lib/gcc/m68k-elf/10.2.0/../../../../m68k-elf/lib/m68k-elf/10.2.0/m68000/ -L/usr/local/Cellar/gcc-cross-m68k@10/10.2.0/lib/gcc/m68k-elf/10.2.0/../../../../m68k-elf/lib/m68000/ kmain.o -o libm_test.bin -lm -lprintf-softfloat -lcstdlib -lmachine -lstart_serial -lgcc  -lprintf
chmod a-x libm_test.bin
```
