### PR TITLE
Fix a compilation issue with Kermit with -09

### DIFF
--- a/code/firmware/rosco_m68k_v1/kermit/kermit.c
+++ b/code/firmware/rosco_m68k_v1/kermit/kermit.c
@@ -1300,7 +1300,7 @@ gattr(struct k_data * k, UCHAR * s, struct k_response * r) {
     UCHAR c;                            /* Workers */
     int aln, i, rc;
 
-    UCHAR sizebuf[SIZEBUFL];
+    UCHAR sizebuf[SIZEBUFL+1];
 
     rc = -1;
     while ((c = *s++)) {		/* Get attribute tag */


### PR DESCRIPTION
# What

Correctly size a buffer in Kermit (add room for a null terminator).

# Why?

The (obsolete but still supported) v1 firmware is compiled with `-O9` instead of `-Os`. When the Kermit code is compiled with that optimisation, it exposes this error (presumably due to the specifics of the way memory is laid out, I haven't had time to dig deeply). This causes a warning on GCC 10, which causes the build to fail as we use `-Werror`.

# Do we need to do this in the 1.1 and 1.2 (and dev) Kermit?

I don't think so. At least, until we've observed incorrect behaviour, we probably shouldn't.
