### PR TITLE
Fix #164 and #165

### DIFF
--- a/code/firmware/rosco_m68k_v1.3/InterfaceReference.md
+++ b/code/firmware/rosco_m68k_v1.3/InterfaceReference.md
@@ -443,8 +443,10 @@ console.
 Register D1.L is expected to contain the function code. Other arguments
 depend on the specific function, and are documented below.
 
-In all cases, registers used as aguments (including D1.L) are **not** 
-guaranteed to be preserved. All other registers are preserved.
+In all cases, registers used as aguments (**excluding** D1.L, which 
+will be preserved unless explicitly documented as used for a return
+value) are **not** guaranteed to be preserved. All 
+other registers are preserved.
 
 Function codes outside the range documented here are considered
 reserved for future expansion, and should not be used by integrators
@@ -479,7 +481,6 @@ MYSTRING    dc.b    "Hello, World!", 0
 
 **Modifies**
 
-* `D1.L` - May be modified arbitrarily
 * `A0`   - Will point to the memory location following the null terminator
 
 **Description**
@@ -509,7 +510,6 @@ hardware). See section 2.3 for details.
 
 **Modifies**
 
-* `D1.L` - May be modified arbitrarily
 * `A0`   - Will point to the memory location following the null terminator
 
 **Description**
@@ -705,7 +705,6 @@ MYSTRING    dc.b    "Hello, World!"
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `A1` - Points to memory location after the last printed character
 
@@ -726,7 +725,6 @@ See also: Function 13
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `A1` - Points to memory location after the last printed character
 
@@ -746,9 +744,7 @@ See also: Function 14
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1.W` - Returns length of read string (Max 80)
-* `D2` - Trashed
 * `(A1)` - Returns the string
 
 **Description**
@@ -764,7 +760,6 @@ Read string from keyboard and store at (A1), NULL terminated, length retuned in 
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Possibly trashed
 
 **Description**
@@ -782,7 +777,6 @@ See also: Functions 15 & 20
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1.L` - Returns the read number
 
 **Description**
@@ -799,7 +793,6 @@ See also: Functions 15 & 20
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1.B` - The read character.
 
 **Description**
@@ -817,7 +810,6 @@ Read single character from the keyboard into D1.B.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 
 **Description**
@@ -832,7 +824,6 @@ Display single character in D1.B.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1.B` - 1 if input pending, 0 otherwise
 
 **Description**
@@ -871,7 +862,6 @@ See also: Function 5
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1.L` - Current number of upticks
 
 **Description**
@@ -921,7 +911,6 @@ intervention.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `D2` - Trashed
 * `A0` - Trashed
@@ -950,7 +939,6 @@ Out of range coordinates are usually ignored (depends on terminal).
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 
 **Description**
@@ -971,7 +959,6 @@ Echo is restored on 'Reset'.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `A1` - Points to memory location after the last printed character
 
@@ -991,7 +978,6 @@ See also: Function 0
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `A1` - Points to memory location after the last printed character
 
@@ -1012,7 +998,6 @@ See also: Function 1
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `D2` - Trashed
 
@@ -1034,7 +1019,6 @@ Values of D2.B outside the range 2 to 36 inclusive are ignored.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 
 **Description**
@@ -1060,7 +1044,6 @@ Input prompt display is enabled by default and by 'Reset'.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `A1` - Trashed
 
@@ -1080,9 +1063,7 @@ Combination of functions 14 & 3.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1.L` - Returns the resulting number
-* `D2` - Trashed
 * `A1` - Trashed
 
 **Description**
@@ -1102,7 +1083,6 @@ Combination of functions 14 & 4.
 
 **Modifies**
 
-* `D0` - Trashed
 * `D1` - Trashed
 * `A1` - Trashed
 

--- a/code/firmware/rosco_m68k_v1.3/bootstrap.S
+++ b/code/firmware/rosco_m68k_v1.3/bootstrap.S
@@ -35,33 +35,33 @@ VECTORS:
     dc.l    GENERIC_HANDLER             ; 09: Trace
     dc.l    GENERIC_HANDLER             ; 0A: Line 1010 Emulator
     dc.l    GENERIC_HANDLER             ; 0B: Line 1111 Emulator
-    dc.l    RESERVED_HANDLER            ; 0C: Reserved
-    dc.l    RESERVED_HANDLER            ; 0D: Reserved
+    dc.l    GENERIC_HANDLER             ; 0C: Reserved
+    dc.l    GENERIC_HANDLER             ; 0D: Reserved
     dc.l    GENERIC_HANDLER             ; 0E: Format error (MC68010 Only)
     dc.l    GENERIC_HANDLER             ; 0F: Uninitialized Vector
     
-    dcb.l   8,RESERVED_HANDLER          ; 10-17: Reserved
+    dcb.l   8,GENERIC_HANDLER           ; 10-17: Reserved
     
     dc.l    GENERIC_HANDLER             ; 18: Spurious Interrupt
     
-    dcb.l   7,INTERRUPT_HANDLER         ; 19-1F: Level 1-7 Autovectors
-    dcb.l   13,TRAP_HANDLER             ; 20-2C: TRAP Handlers (unused)
-    dc.l    TRAP_HANDLER                ; 2D: TRAP#13 handler (replaced later)
+    dcb.l   7,GENERIC_HANDLER           ; 19-1F: Level 1-7 Autovectors
+    dcb.l   13,GENERIC_HANDLER          ; 20-2C: TRAP Handlers (unused)
+    dc.l    GENERIC_HANDLER             ; 2D: TRAP#13 handler (replaced later)
     dc.l    TRAP_14_HANDLER             ; 2E: TRAP#14 handler
-    dc.l    TRAP_HANDLER                ; 2F: TRAP#15 handler (replaced later)
-    dcb.l   16,RESERVED_HANDLER         ; 30-3F: Remaining Reserved vectors
-    dcb.l   4,UNMAPPED_USER_HANDLER     ; 40-43: MFP GPIO #0-3 (Not used)
-    dc.l    UNMAPPED_USER_HANDLER       ; 44: MFP Timer D (Interrupt not used)
+    dc.l    GENERIC_HANDLER             ; 2F: TRAP#15 handler (replaced later)
+    dcb.l   16,GENERIC_HANDLER          ; 30-3F: Remaining Reserved vectors
+    dcb.l   4,GENERIC_HANDLER           ; 40-43: MFP GPIO #0-3 (Not used)
+    dc.l    GENERIC_HANDLER             ; 44: MFP Timer D (Interrupt not used)
     dc.l    TICK_HANDLER                ; 45: MFP Timer C (System tick)
-    dcb.l   2,UNMAPPED_USER_HANDLER     ; 46-47: MFP GPIO #4-5 (Not used)
-    dc.l    UNMAPPED_USER_HANDLER       ; 48: MFP Timer B (Not used)
-    dc.l    UNMAPPED_USER_HANDLER       ; 49: Transmitter error (Not used)
-    dc.l    UNMAPPED_USER_HANDLER       ; 4A: Transmitter empty (Replaced later)
-    dc.l    UNMAPPED_USER_HANDLER       ; 4B: Receiver error (Replaced later)
-    dc.l    UNMAPPED_USER_HANDLER       ; 4C: Receiver buffer full (Replaced later)
-    dc.l    UNMAPPED_USER_HANDLER       ; 4D: Timer A (Not used)
-    dcb.l   2,UNMAPPED_USER_HANDLER     ; 4E-4F: MFP GPIO #6-7 (Not used)
-    dcb.l   176,UNMAPPED_USER_HANDLER   ; 50-FF: Unused user vectors
+    dcb.l   2,GENERIC_HANDLER           ; 46-47: MFP GPIO #4-5 (Not used)
+    dc.l    GENERIC_HANDLER             ; 48: MFP Timer B (Not used)
+    dc.l    GENERIC_HANDLER             ; 49: Transmitter error (Not used)
+    dc.l    GENERIC_HANDLER             ; 4A: Transmitter empty (Replaced later)
+    dc.l    GENERIC_HANDLER             ; 4B: Receiver error (Replaced later)
+    dc.l    GENERIC_HANDLER             ; 4C: Receiver buffer full (Replaced later)
+    dc.l    GENERIC_HANDLER             ; 4D: Timer A (Not used)
+    dcb.l   2,GENERIC_HANDLER           ; 4E-4F: MFP GPIO #6-7 (Not used)
+    dcb.l   176,GENERIC_HANDLER         ; 50-FF: Unused user vectors
     
 VEC_END:
 VERSION:
@@ -194,45 +194,29 @@ INITSDB:
 
     ; Setup default implementations in EFP table.
 .USEDUART:
-    lea     EARLY_PRINT_DUART,A0
-    move.l  A0,EFP_PRINT
-    lea     EARLY_PRINTLN_DUART,A0
-    move.l  A0,EFP_PRINTLN
-    lea     SENDCHAR_DUART,A0
-    move.l  A0,EFP_PRINTCHAR
-    lea     SENDCHAR_DUART,A0
-    move.l  A0,EFP_SENDCHAR
-    lea     RECVCHAR_DUART,A0
-    move.l  A0,EFP_RECVCHAR
-    lea     CHECKCHAR_DUART,A0
-    move.l  A0,EFP_CHECKCHAR
+    move.l  #EARLY_PRINT_DUART,EFP_PRINT
+    move.l  #EARLY_PRINTLN_DUART,EFP_PRINTLN
+    move.l  #SENDCHAR_DUART,EFP_PRINTCHAR
+    move.l  #SENDCHAR_DUART,EFP_SENDCHAR
+    move.l  #RECVCHAR_DUART,EFP_RECVCHAR
+    move.l  #CHECKCHAR_DUART,EFP_CHECKCHAR
     bra.s   .COMMON
     
     endif
 
 .USEMFP:
-    lea     EARLY_PRINT_MFP,A0
-    move.l  A0,EFP_PRINT
-    lea     EARLY_PRINTLN_MFP,A0
-    move.l  A0,EFP_PRINTLN
-    lea     SENDCHAR_MFP,A0
-    move.l  A0,EFP_PRINTCHAR
-    lea     SENDCHAR_MFP,A0
-    move.l  A0,EFP_SENDCHAR
-    lea     RECVCHAR_MFP,A0
-    move.l  A0,EFP_RECVCHAR
-    lea     CHECKCHAR_MFP,A0
-    move.l  A0,EFP_CHECKCHAR
+    move.l  #EARLY_PRINT_MFP,EFP_PRINT
+    move.l  #EARLY_PRINTLN_MFP,EFP_PRINTLN
+    move.l  #SENDCHAR_MFP,EFP_PRINTCHAR
+    move.l  #SENDCHAR_MFP,EFP_SENDCHAR
+    move.l  #RECVCHAR_MFP,EFP_RECVCHAR
+    move.l  #CHECKCHAR_MFP,EFP_CHECKCHAR
     
 .COMMON
-    lea     HALT,A0
-    move.l  A0,EFP_HALT
-    lea     ANSI_MOVEXY,A0
-    move.l  A0,EFP_MOVEXY
-    lea     ANSI_CLRSCR,A0
-    move.l  A0,EFP_CLRSCR
-    lea     .RETURN,A0               ; No-op for default SET CURSOR
-    move.l  A0,EFP_SETCURSOR
+    move.l  #HALT,EFP_HALT
+    move.l  #ANSI_MOVEXY,EFP_MOVEXY
+    move.l  #ANSI_CLRSCR,EFP_CLRSCR
+    move.l  #.RETURN,EFP_SETCURSOR     ; No-op for default SET CURSOR
 
 .RETURN
     rts
@@ -296,7 +280,6 @@ INITMFP:
                                       ; (kmain will call START_HEART later)
     
     ; Indicate success and return
-    move.b  #$FE,MFP_GPDR             ; Turn on GPIO #0 (Green LED)
     rts
 
 
@@ -405,13 +388,7 @@ INITDUART:
     ;move.b  #$ff,W_OPR_RESETCMD       ; Clear all OP bits (lower RTS)
     ;move.b  #0,W_OPR_SETCMD
 
-    ; Final check - if there were any bus errors during setup, then there isn't
-    ; a 68681 installed after all. Unfortunately, We have probably trashed whatever
-    ; _is_ in IO space in the 68681's range at this point...
-    tst.b   $504                      ; Was there a bus error?
-    bne.s   .DONE                     ; Bail now if so...
-
-    ; Otherwise, looks like we successfully initialized a 68681!
+    ; Looks like we successfully initialized a 68681!
     move.b  #1,D5                     ; Set D5 to indicate to INITSDB that there's a DUART present...
  .DONE:
     move.l  $500,$8                   ; Restore bus error handler
@@ -572,22 +549,6 @@ ILLEGAL_INSTRUCTION_HANDLER:
 GENERIC_HANDLER:
     move.l  #$2BADB105,$404
     rte
-    
-RESERVED_HANDLER:
-    move.l  #$0BADC0DE,$404
-    rte
-    
-UNMAPPED_USER_HANDLER:
-    move.l  #$002BAD05,$404
-    rte
-    
-INTERRUPT_HANDLER:
-    move.l  #$0BADF00D,$404
-    rte
-
-TRAP_HANDLER:
-    move.l  #$C001C0DE,$404
-    rte
 
 
 ; Convenience SEND/RECV char functions, using the EFP table.
@@ -707,7 +668,7 @@ RECVCHAR_MFP:
 ; Consts 
     section .rodata
 
-SZ_BANNER0      dc.b    $D, $A, $1B, "[1;33m                                 ___ ___ _   ", $D, $A
+SZ_BANNER0      dc.b    $D, $A, $1B, "[1;33m                                 ___ ___ _", $D, $A
 SZ_BANNER1      dc.b    " ___ ___ ___ ___ ___       _____|  _| . | |_ ", $D, $A
 SZ_BANNER2      dc.b    "|  _| . |_ -|  _| . |     |     | . | . | '_|", $D, $A
 SZ_BANNER3      dc.b    "|_| |___|___|___|___|_____|_|_|_|___|___|_,_|", $D, $A

--- a/code/firmware/rosco_m68k_v1.3/easy68k/syscalls_asm.S
+++ b/code/firmware/rosco_m68k_v1.3/easy68k/syscalls_asm.S
@@ -32,6 +32,8 @@ RESERVED            equ     $413
 ; D0 is expected to contain the task number (function code). Other arguments
 ; depend on the specific function - See README for details.
 EASY68K_TRAP_15_HANDLER:
+    move.l  D0,-(A7)                    ; Save function code
+    
     cmp.l   #20,D0                      ; Is function code in range?
     bhi.s   .DONE                       ; Nope, leave...
 
@@ -54,7 +56,7 @@ JUMPTABLE:
     dc.l    CHECK_RECV                  ; FC == 7
     dc.l    GET_TICKS                   ; FC == 8
     dc.l    HALT                        ; FC == 9
-    dc.l    .NOT_IMPLEMENTED            ; FC == 10
+    dc.l    EPILOGUE                    ; FC == 10 (NOT IMPLEMENTED)
     dc.l    MOVE_X_Y                    ; FC == 11
     dc.l    SET_ECHO                    ; FC == 12
     dc.l    PRINTLN_SZ                  ; FC == 13
@@ -63,28 +65,31 @@ JUMPTABLE:
     dc.l    SET_DISPLAY_OPTS            ; DC == 16
     dc.l    PRINT_SZ_PRINT_NUM          ; DC == 17
     dc.l    PRINT_SZ_READ_NUM           ; DC == 18
-    dc.l    .NOT_IMPLEMENTED            ; DC == 19
+    dc.l    EPILOGUE                    ; DC == 19 (NOT IMPLEMENTED)
     dc.l    DISPLAYNUM_SIGNED_WIDTH     ; DC == 20
 
-.NOT_IMPLEMENTED:
+; N.B. If changing this EPILOGUE, be sure to change EPILOGUE2 at the bottom
+; of the file to match!
+EPILOGUE:
+    move.l  (A7)+,D0                    ; Restore function code
     rte
 
 * ************************************************************************** *
 * ************************************************************************** *
-; The individual handlers. These are responsible for handling the rte,
-; and should not return to the main handler!
+; The individual handlers. They should jump back toEPILOGUE once complete
+; so that the stack / registers can be restored.
 * ************************************************************************** *
 PRINTLN_LEN:
     bsr.s   PRINT_LEN_IMPL              ; Print the string...
     lea     SZ_CRLF,A0                  ; Load CRLF...
     bsr.w   FW_PRINT                    ; ... and print it
-    rte
+    bra.s   EPILOGUE                   
 
 
 * ************************************************************************** *
 PRINT_LEN:
     bsr.s   PRINT_LEN_IMPL              ; Do the print...
-    rte                                 ; ... and done.
+    bra.s   EPILOGUE                   
 
 ; Sub used for both PRINT_LEN and PRINTLN_LEN
 PRINT_LEN_IMPL:
@@ -103,6 +108,7 @@ PRINT_LEN_IMPL:
 * ************************************************************************** *
 READLN_STR:
     move.l  A1,-(A7)                    ; Store buffer start
+    move.l  D2,-(A7)                    ; Store scratch register
 
     move.b  PROMPT_ON,D2                ; Get display prompt flag
     tst.b   D2                          ; Is it non-zero?
@@ -145,8 +151,9 @@ READLN_STR:
     add.w   #1,D1
     sub.w   D1,D0
     move.w  D0,D1                       ; Shuffle around to stay compatible...
-    move.l  (A7)+,A1                    ; ... and restore buffer pointer
-    rte
+    move.l  (A7)+,D2                    ; ... restore scratch reg
+    move.l  (A7)+,A1                    ; ... and buffer pointer
+    bra.w   EPILOGUE                   
 
 
 * ************************************************************************** *
@@ -154,15 +161,18 @@ DISPLAYNUM_SIGNED:
     move.l  D1,-(A7)                    ; Stack argument...
     bsr.w   print_signed                ; ... and call
     addq    #4,A7                       ; Cleanup stack
-    rte                                 ; And done!
+    bra.w   EPILOGUE                   
 
 
 * ************************************************************************** *
 READLN_NUM:
     bsr.s   READLN_NUM_IMPL
-    rte
+    bra.w   EPILOGUE                   
 
 READLN_NUM_IMPL:
+    move.l  D2,-(A7)                    ; Save scratch registers
+    move.l  D3,-(A7)                    ; ...
+
     move.b  PROMPT_ON,D2                ; Get display prompt flag
     tst.b   D2                          ; Is it non-zero?
     beq.s   .READ                       ; Nope, skip prompt display
@@ -214,20 +224,22 @@ READLN_NUM_IMPL:
     bsr.w   FW_PRINTCHAR
 
 .RETURN
+    move.l  (A7)+,D3                    ; Restore scratch registers
+    move.l  (A7)+,D2                    ; ...
     rts
 
 * ************************************************************************** *
 READ_CHAR:
     bsr.w   RECVCHAR                    ; Call RECVCHAR
     move.l  D0,D1                       ; Platform code returns in D0...
-    rte
+    bra.w   EPILOGUE                   
 
 
 * ************************************************************************** *
 SEND_CHAR:
     move.l  D1,D0                       ; Platform code expects arg in D0...
     bsr.w   SENDCHAR
-    rte
+    bra.w   EPILOGUE                   
 
 
 * ************************************************************************** *
@@ -239,17 +251,17 @@ CHECK_RECV:
     bne.s   .TRUE                       ; Yes - Go to set true
 
     move.b  #0,D1                       ; Else no - so false
-    rte                                 ; And done.
+    bra.w   EPILOGUE2                   
 
 .TRUE:
     move.b  #1,D1                       ; Set true
-    rte                                 ; And done.
+    bra.w   EPILOGUE2                   
 
 
 * ************************************************************************** *
 GET_TICKS:
     move.w  $408,D1                     ; Get (Word-sized!) count from SDB
-    rte
+    bra.w   EPILOGUE2                   
 
 
 * ************************************************************************** *
@@ -259,31 +271,37 @@ MOVE_X_Y:
 
 .MOVEXY
     bsr.w   FW_MOVEXY
-    rte                                 ; and done!
+    bra.w   EPILOGUE2                   
 
 .CLRSCR
     bsr.w   FW_CLRSCR
-    rte
+    bra.w   EPILOGUE2                   
 
 
 * ************************************************************************** *
 SET_ECHO:
     move.b  D1,ECHO_ON
-    rte
+    bra.w   EPILOGUE2
 
 
 * ************************************************************************** *
 PRINTLN_SZ:
-    movea.l A1,A0
+    move.l  A0,-(A7)
+    move.l  A1,A0
     bsr.w   FW_PRINTLN
-    rte
+    move.l  A0,A1
+    move.l  (A7)+,A0
+    bra.w   EPILOGUE2                  
 
 
 * ************************************************************************** *
 PRINT_SZ:
-    movea.l A1,A0
+    move.l  A0,-(A7)
+    move.l  A1,A0
     bsr.w   FW_PRINT
-    rte
+    move.l  A0,A1
+    move.l  (A7)+,A0
+    bra.w   EPILOGUE2 
 
 
 * ************************************************************************** *
@@ -292,7 +310,7 @@ DISPLAYNUM_UNSIGNED:
     move.l  D1,-(A7)                    ; ... and number
     bsr.w   print_unsigned              ; ... and call.
     addq    #8,A7                       ; Cleanup stack
-    rte                                 ; Fin!
+    bra.w   EPILOGUE2                  
 
 
 * ************************************************************************** *
@@ -305,43 +323,48 @@ SET_DISPLAY_OPTS:
     beq     .LF_OFF                     ;   Linefeed disable if so, else...
     cmp.b   #3,D1                       ; Is D1 3?
     beq     .LF_ON                      ;   Linefeed enable if so, else...
-    rte                                 ; Ignore.
+    bra.s   EPILOGUE2
 
 .PROMPT_OFF:
     move.b  0,PROMPT_ON
-    rte
+    bra.s   EPILOGUE2
 
 .PROMPT_ON
     move.b  1,PROMPT_ON
-    rte
+    bra.s   EPILOGUE2
 
 .LF_OFF:
     move.b  0,LF_DISPLAY
-    rte
+    bra.s   EPILOGUE2
 
 .LF_ON:
     move.b  1,LF_DISPLAY
-    rte
+    bra.s   EPILOGUE2
 
 
 * ************************************************************************** *
 PRINT_SZ_PRINT_NUM:
+    move.l  A0,-(A7)
     movea.l A1,A0                       ; Move arg for FW_PRINT...
     bsr.w   FW_PRINT                    ; ... and call it
 
     move.l  D1,-(A7)                    ; Stack number argument...
     bsr.w   print_signed                ; ... and call
     addq    #4,A7                       ; Cleanup stack
-    rte                                 ; And done!
+    
+    move.l  (A7)+,A0
+    bra.s   EPILOGUE2
 
 
 * ************************************************************************** *
 PRINT_SZ_READ_NUM:
+    move.l  A0,-(A7)
     movea.l A1,A0                       ; Move arg for FW_PRINT...
     bsr.w   FW_PRINT                    ; ... and call it
 
     bsr.w   READLN_NUM_IMPL             ; Then read a number into D1
-    rte
+    move.l  (A7)+,A0
+    bra.s   EPILOGUE2
 
 
 * ************************************************************************** *
@@ -350,8 +373,11 @@ DISPLAYNUM_SIGNED_WIDTH:
     move.l  D1,-(A7)                    ; ... and number
     bsr.w   print_signed_width          ; ... and call.
     addq    #8,A7                       ; Cleanup stack
-    rte                                 ; Fin!
 
+
+EPILOGUE2:
+    move.l  (A7)+,D0                    ; Restore function code
+    rte
 
 * ************************************************************************** *
 * ************************************************************************** *

--- a/code/firmware/rosco_m68k_v1.3/trap14.S
+++ b/code/firmware/rosco_m68k_v1.3/trap14.S
@@ -24,8 +24,10 @@
 ; This is the exception handler...
 TRAP_14_HANDLER::
     move.l  A1,-(A7)
+    move.l  D1,-(A7)
+
     cmp.l   #6,D1                       ; Is function code in range?
-    bhi.s   .NOT_IMPLEMENTED            ; Nope, leave...
+    bhi.s   .EPILOGUE                   ; Nope, leave...
 
     add.l   D1,D1                       ; Multiply FC...
     add.l   D1,D1                       ; ... by 4...
@@ -41,7 +43,8 @@ TRAP_14_HANDLER::
     dc.l    .SETCURSOR                  ; FC == 5 ; SETCURSOR if so...
     dc.l    .CHECKCHAR                  ; FC == 6 ; CHECKCHAR if so...
     
-.NOT_IMPLEMENTED
+.EPILOGUE
+    move.l  (A7)+,D1
     move.l  (A7)+,A1
     rte                                 ; That's all for now...
 
@@ -49,44 +52,37 @@ TRAP_14_HANDLER::
 .PRINT
     move.l  EFP_PRINT,A1
     jsr     (A1)
-    move.l  (A7)+,A1
-    rte
+    bra.s   .EPILOGUE
 
 .PRINTLN
     move.l  EFP_PRINTLN,A1
     jsr     (A1)
-    move.l  (A7)+,A1
-    rte
+    bra.s   .EPILOGUE
 
 .SENDCHAR
     move.l  EFP_SENDCHAR,A1
     jsr     (A1)
-    move.l  (A7)+,A1
-    rte
+    bra.s   .EPILOGUE
 
 .RECVCHAR
     move.l  EFP_RECVCHAR,A1
     jsr     (A1)
-    move.l  (A7)+,A1
-    rte
+    bra.s   .EPILOGUE
     
 .PRINTCHAR
     move.l  EFP_PRINTCHAR,A1
     jsr     (A1)
-    move.l  (A7)+,A1
-    rte
+    bra.s   .EPILOGUE
 
 .SETCURSOR
     move.l  EFP_SETCURSOR,A1
     jsr     (A1)
-    move.l  (A7)+,A1
-    rte
+    bra.s   .EPILOGUE
 
 .CHECKCHAR
     move.l  EFP_CHECKCHAR,A1
     jsr     (A1)
-    move.l  (A7)+,A1
-    rte
+    bra.s   .EPILOGUE
 
 
 ; Wraps FW_PRINT so it can be called from C-land


### PR DESCRIPTION
# What?

Stop TRAP 14 and TRAP 15 stomping on so many registers (particularly the function code register, which is super annoying when calling the same trap in a loop).

# Issues

* #164 
* #165 

# What else?

There's a bunch of other stuff in here to reduce size, as fixing the issues with the TRAPs blew the small ROM size limit. There are _technically_ breaking changes, but nothing that I think anyone will care about (e.g. the different unmapped exception handlers for different exception ranges are gone, and replaced by a single generic one. This means that the same code will be written to the system status regardless of which type of unmapped exception was triggered. I seriously doubt anyone cares about that...).

Docs updated to reflect the changes in the TRAPs.

(All tested locally with regular programs and the Easy68k demo program, plus verified small and big ROM builds still work, and unrelated stuff like SD is still good).