### PR TITLE
Add C exceptions header, and example of C exception handler

### DIFF
--- a/code/software/exception_tests/Makefile
+++ b/code/software/exception_tests/Makefile
@@ -1,0 +1,56 @@
+# Make rosco_m68k programs
+# 
+# Copyright (c)2020 Ross Bamford
+# See LICENSE
+
+EXTRA_CFLAGS?=
+SYSINCDIR?=../libs/build/include
+SYSLIBDIR?=../libs/build/lib
+LIBS=-lprintf -lcstdlib -lmachine -lstart_serial -lgcc
+GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
+		| grep libraries:\ =																								\
+    | sed 's/libraries: =/-L/g' 																				\
+    | sed 's/:/m68000\/ -L/g')m68000/
+DEFINES=-DROSCO_M68K
+CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
+			 -mcpu=68010 -march=68010 -mtune=68010 -fomit-frame-pointer				\
+			 -mno-align-int -mno-strict-align $(DEFINES)
+LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
+				-Map=$(MAP)
+ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
+CC=m68k-elf-gcc
+LD=m68k-elf-ld
+AS=vasmm68k_mot
+RM=rm -f
+
+KERMIT=kermit
+SERIAL?=/dev/modem
+BAUD?=9600
+
+# Output config
+BINARY_BASENAME=exceptions
+BINARY_EXT=bin
+MAP=$(BINARY_BASENAME).map
+BINARY=$(BINARY_BASENAME).$(BINARY_EXT)
+
+OBJECTS=kmain.o funcs.o
+
+%.o : %.c
+	$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $<
+
+%.o : %.asm
+	$(AS) $(ASFLAGS) -o $@ $<
+
+$(BINARY) : $(OBJECTS)
+	$(LD) $(LDFLAGS) $(GCC_LIBS) $^ -o $@ $(LIBS)
+	chmod a-x $@
+
+.PHONY: all clean load
+
+all: $(BINARY)
+
+clean: 
+	$(RM) $(OBJECTS) $(BINARY) $(BINARY_ODD) $(BINARY_EVEN) $(MAP)
+
+load: $(BINARY)
+	kermit -i -l $(SERIAL) -b $(BAUD) -s $(BINARY)

--- a/code/software/exception_tests/README.md
+++ b/code/software/exception_tests/README.md
@@ -1,0 +1,47 @@
+# C Exception Handling example for rosco_m68k
+
+This project uses the `<machine/exceptions.h>` header from the standard 
+library to implement fairly-easy-to-use C exception handlers. 
+
+These use a tiny Assembler stub to call the C handler with the stack 
+set up correctly. `__attribute__((interrupt))` is not used, as that 
+attribute doesn't affect where GCC looks for arguments on the stack, 
+so makes it more difficult to pass in the `CPUExceptionFrame` structure
+to the handler.
+
+Instead, the stub does a `JSR` to the handler, which leaves the stack
+in an appropriate state for the struct to just be the argument to the
+handler.
+
+In this example, the C handler is a bus error handler. Bus error handlers
+are required to do some work with the exception frame in order to tell
+the CPU what they want to do. Here, all that work is done in C, using
+the main `CPUExceptionFrame` struct and the various `define`s from the
+`machine/exceptions` header.
+ 
+## What next?
+
+* Have a look at `kmain.c` to see the C handler.
+* Have a look at `funcs.asm` to see the (tiny) stub and how it's installed.
+* Build and run to see it in action!
+
+## Building
+
+```
+make clean all
+```
+
+This will build `exceptions.bin`, which can be uploaded to a board that
+is running the `serial-receive` firmware, or placed on an SD card
+(Firmware 1.3 and up).
+
+If you're feeling adventurous (and have ckermit installed), you
+can try:
+
+```
+SERIAL=/dev/some-serial-device make load
+```
+
+which will attempt to send the binary directly to your board (which
+must obviously be connected and waiting for the upload).
+

--- a/code/software/exception_tests/funcs.asm
+++ b/code/software/exception_tests/funcs.asm
@@ -15,11 +15,16 @@
 
     section .text
 
-; This is the stub exception handler. It does nothing more that
-; JSR to our C exception handler. It's needed to make the stack
-; behave as GCC expects.
+; This is the stub exception handler. It saves registers and 
+; sets up a pointer to the stacked CPU data for the C handler
+; to take as an argument, then calls the handler.
 BERR_HANDLER:
+    movem.l D0-D1/A0-A1,-(A7)
+    lea     16(A7),A0
+    move.l  A0,-(A7)
     jsr     berr_handler_c
+    addq.l  #4,A7
+    movem.l (A7)+,D0-D1/A0-A1
     rte
 
 

--- a/code/software/exception_tests/funcs.asm
+++ b/code/software/exception_tests/funcs.asm
@@ -1,0 +1,40 @@
+;
+;------------------------------------------------------------
+;                                  ___ ___ _
+;  ___ ___ ___ ___ ___       _____|  _| . | |_
+; |  _| . |_ -|  _| . |     |     | . | . | '_|
+; |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+;                     |_____|       firmware v1
+; ------------------------------------------------------------
+; Copyright (c)2021 Ross Bamford
+; See top-level LICENSE.md for licence information.
+;
+; C Exception Handling example
+; ------------------------------------------------------------
+;
+
+    section .text
+
+; This is the stub exception handler. It does nothing more that
+; JSR to our C exception handler. It's needed to make the stack
+; behave as GCC expects.
+BERR_HANDLER:
+    jsr     berr_handler_c
+    rte
+
+
+; Convenience function to install our handler
+INSTALL_HANDLER::
+    move.l  $8,saved
+    move.l  #BERR_HANDLER,$8
+    rts
+
+
+; Convenience function to restore the original handler
+UNINSTALL_HANDLER::
+    move.l  saved,$8
+    rts
+
+    section .data
+saved   ds.l    1
+ 

--- a/code/software/exception_tests/kmain.c
+++ b/code/software/exception_tests/kmain.c
@@ -1,0 +1,96 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+ *                     |_____|       firmware v1
+ * ------------------------------------------------------------
+ * Copyright (c) 2021 Ross Bamford (roscopeco <at> gmail <dot> com).
+ * See top-level LICENSE.md for licence information.
+ *
+ * This is an example of using the ExceptionFrame structure in a 
+ * C exception handler (called by an ASM stub to make the stack 
+ * right) to handle a bus error from C code.
+ * ------------------------------------------------------------
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <machine/exception.h>
+
+extern void INSTALL_HANDLER();
+extern void UNINSTALL_HANDLER();
+
+static volatile bool berr_hit = false;
+static volatile uint16_t fmt = 0x1234;
+static volatile uint16_t sr = 0x1234;
+static volatile uint32_t pc = 0x12341234;
+static volatile uint16_t vec_ofs = 0x1234;
+static volatile uint8_t cpuver = 0;
+
+static uint32_t *bad = (uint32_t*)0x00f00000;
+
+/* 
+ * Example of a C Bus Error handler. Note that this is *not* directly an 
+ * exception handler (attribute interrupt) function - instead, it is called
+ * by an assembler stub using JSR. This is because, even with the interrupt
+ * attribute, GCC still offsets addresses into a stacked struct by 4 even
+ * though interrupt handlers do not have a return address on the stack.
+ *
+ * It's also worth noting that this is manipulating the passed in frame
+ * directly, which is re-read by the CPU when the handler is done and 
+ * (in this case) causes it to consider the bus error as handled in software.
+ */
+void berr_handler_c(CPUExceptionFrame frame) {
+  // indicate to the main code that the bus error handler has been run
+  berr_hit = true;
+
+  // Set some data for the main code to read after the exception
+  fmt = frame.format;
+  sr = frame.sr;
+  pc = frame.pc;
+  vec_ofs = frame.vec_ofs;
+
+  // Handle the bus error appropriately for the CPU type (determined by the format code).
+  switch (frame.format) {
+  case EX_FMT_010_BERR:
+    // 68010 - Set bit 15 in SSW
+    cpuver = 1;
+    frame.fmt010.ssw |= EX_M010_SSW_RR_MASK;  /* Set the Rerun flag, indicating that we handled the re-run */
+    frame.fmt010.data_in_buffer = 0xF00D;     /* Make the faulting read return 0xF00D (only 16-bit on 68010) */
+    break;
+  case EX_FMT_020_BERR_SHORT:
+  case EX_FMT_020_BERR_LONG:
+    // 68020 - Clear bit 8 in SSW
+    cpuver = 2;
+    frame.fmt020.ssw &= ~EX_M020_SSW_DF_MASK; /* Clear the Data Fault flag, indicating we don't want re-run */
+    frame.fmt020.data_in_buffer = 0x2BADF00D; /* Instead, make it seem that the read returned 0x2BADF00D */
+    break;
+  default:
+    // Unknown / 68000
+    break;
+  }
+}
+
+/* Simple kmain to demonstrate the bus error handler */
+void kmain() {
+  INSTALL_HANDLER();
+
+  // Generate a bus fault
+  printf("Bad is 0x%08x\r\n", *bad);
+
+  if (berr_hit) {
+    printf("\nBus Error occurred:\r\n");
+    printf("    Format was 0b%04b     (Indicating 680%d0 CPU)\r\n", fmt, cpuver);
+    printf("    VecOfs was 0x%06x   (Exception #%d)\r\n", vec_ofs, vec_ofs / 4);
+    printf("    SR     was 0x%04x\r\n", sr);
+    printf("    PC     was 0x%08x\r\n", pc);
+  } else {
+    printf("Bus Error did not occur.\r\n");
+  }
+
+  UNINSTALL_HANDLER();
+}
+

--- a/code/software/libs/src/machine/include/machine/exception.h
+++ b/code/software/libs/src/machine/include/machine/exception.h
@@ -1,0 +1,103 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _   
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
+ *                     |_____|       firmware v1                 
+ * ------------------------------------------------------------
+ * Copyright (c)2019 Ross Bamford
+ * See top-level LICENSE.md for licence information.
+ *
+ * C defines, structs etc for dealing with M68k exceptions
+ * ------------------------------------------------------------
+ */
+#ifndef _ROSCOM68K_MACHINE_EXCEPTION_H
+#define _ROSCOM68K_MACHINE_EXCEPTION_H
+
+#include <stdint.h>
+
+/*
+ * Exception frame format on the stack. Not all fields are present
+ * for all exception types - the fields that are valid are determined
+ * by the exception vector and format code.
+ */
+typedef struct {
+  uint16_t sr;                      /* Status register                  */
+  uint32_t pc;                      /* Program counter                  */
+  uint16_t format: 4;               /* Format code                      */
+  uint16_t vec_ofs: 12;             /* Vector offset                    */
+  union {
+    struct {
+      uint16_t ssw;                 /* 68010 Special Status Word        */
+      uint32_t fault_address;       /* 68010 Fault address              */
+      uint16_t reserved0;
+      uint16_t data_out_buffer;     /* 68010 Data output buffer         */
+      uint16_t reserved1;
+      uint16_t data_in_buffer;      /* 68010 Data input buffer          */
+      uint16_t reserved2;
+      uint16_t insn_in_buffer;      /* 68010 Instruction input buffer   */
+
+      // |VERSION NUMBER| (?) / 16 words of internal registers may follow
+    } fmt010;
+    struct {
+      union {
+        uint32_t insn_address;      /* 68020 Instruction address        */
+        struct {
+          uint16_t reserved0;
+          uint16_t ssw;             /* 68020 Special Status Word        */
+        };
+      }; 
+      uint16_t pipe_stage_c;        /* 68020 Instruction pipe - Stage C */
+      uint16_t pipe_state_b;        /* 68020 Instruction pipe - Stage B */
+      uint32_t fault_address;       /* 68020 Fault address              */
+      uint32_t reserved1;
+      uint32_t data_out_buffer;     /* 68020 Data output buffer         */
+      uint32_t reserved2;
+      uint32_t reserved3;
+      uint32_t stage_b_address;     /* 68020 Stage B address            */
+      uint32_t reserved4;
+      uint32_t data_in_buffer;      /* 68020 Data input buffer          */
+      uint32_t reserved5;
+      uint16_t reserved6;
+      uint16_t version: 4;          /* 68020 frame Version number       */
+      uint16_t reserved7: 12;
+
+      // 18 words of internal registers may follow (long bus fault frame)
+    } fmt020;
+  };
+} __attribute__((packed)) CPUExceptionFrame;
+
+#ifndef ROSCOM68K_QUIET_INCLUDES
+/* Format codes */
+#define EX_FMT_FOUR_WORD       0x0     /* 0b0000: Basic four-word frame */
+#define EX_FMT_TW_FOUR_WORD    0x1     /* 0b0001: Throwaway four-word frame (68020+) */
+#define EX_FMT_SIX_WORD        0x2     /* 0b0010: Six-word frame (68020+) */
+#define EX_FMT_010_BERR        0x8     /* 0b1000: Twenty-nine word 68010 bus error frame (68010 only) */
+#define EX_FMT_COPRO_MID       0x9     /* 0b1001: Coprocessor midinstruction frame (ten word, 68020+) */
+#define EX_FMT_020_BERR_SHORT  0xA     /* 0b1010: Short 68020 address/bus fault frame (sixteen word, 68020+) */
+#define EX_FMT_020_BERR_LONG   0xB     /* 0b1011: Long 68020 address/bus fault frame (forty-six word, 68020+) */
+
+/* MC68020 Special Status Word Bits */
+#define EX_M020_SSW_FC_MASK    0x8000  /* Fault on Stage C */
+#define EX_M020_SSW_FB_MASK    0x4000  /* Fault on Stage B */
+#define EX_M020_SSW_RC_MASK    0x2000  /* Rerun flag for Stage C; 1 for re-run, 0 for don't re-run */
+#define EX_M020_SSW_RB_MASK    0x1000  /* Rerun flag for Stage B; 1 for re-run, 0 for don't re-run */
+#define EX_M020_SSW_DF_MASK    0x0100  /* Data Fault indicator & rerun flag - set 1 for re-run, 0 for don't re-run */
+#define EX_M020_SSW_RM_MASK    0x0080  /* Read-modify-write cycle */
+#define EX_M020_SSW_RW_MASK    0x0040  /* 0 for write, 1 for read */
+#define EX_M020_SSW_SIZE_MASK  0x0030  /* Size code */
+#define EX_M020_SSW_FCODE_MASK 0x0007  /* Function codes for data cycle */
+
+/* MC68010 Special Status Word Bits */
+#define EX_M010_SSW_RR_MASK    0x8000  /* Rerun flag - 0 for processor, 1 for software */
+#define EX_M010_SSW_IF_MASK    0x2000  /* Instruction fetch to input buffer */
+#define EX_M010_SSW_DF_MASK    0x1000  /* Data fetch to input buffer */
+#define EX_M010_SSW_RM_MASK    0x0800  /* Read-modify-write cycle */
+#define EX_M010_SSW_HB_MASK    0x0400  /* High-byte transfer */
+#define EX_M010_SSW_BY_MASK    0x0200  /* 1 for byte transfer, 0 for word transfer */
+#define EX_M010_SSW_RW_MASK    0x0100  /* 0 for write, 1 for read */
+#define EX_M010_SSW_FCODE_MASK 0x0007  /* Function codes for faulted access */ 
+#endif // ROSCOM68K_QUIET_INCLUDES
+
+#endif // _ROSCOM68K_MACHINE_EXCEPTION_H


### PR DESCRIPTION
This came out of something I was playing with recently, and I think it might be generally useful (or at least a good example). 

* Adds `<machine/exception.h>` which has C struct version of the CPU's exception stack frame (For 68000/010/020 at least)
* Adds an example of using the new header (plus an assembler stub) to implement a C exception handler
