### PR TITLE
Fix build when 68681 is disabled

### DIFF
--- a/code/firmware/rosco_m68k_v1.3/bootstrap.S
+++ b/code/firmware/rosco_m68k_v1.3/bootstrap.S
@@ -384,6 +384,7 @@ INITDUART_ATBASE:
  .DONE:
     move.l  $500,$8                   ; Restore bus error handler
     rts
+    endif
 
 ; Temporary bus error handler, in case no MC68681 is installed
 BERR_HANDLER::
@@ -411,8 +412,6 @@ BERR_HANDLER::
     move.b  #1,$504
     move.w  (A7)+,D0
     rte
-
-    endif
     
     
 ;------------------------------------------------------------


### PR DESCRIPTION
Just moves some conditional assembly to allow the firmware to be built without the 68681 (The VDP code uses the bus error handler, which was previously only conditionally assembled based on 68681 and so caused the build to fail).