### PR TITLE
First cut Xosera console

### DIFF
--- a/code/firmware/rosco_m68k_development/Makefile
+++ b/code/firmware/rosco_m68k_development/Makefile
@@ -58,6 +58,10 @@ ifneq ($(WITH_VDP),false)
 include video9958/include.mk
 endif
 
+ifneq ($(WITH_XVID),false)
+include videoXosera/include.mk
+endif
+
 ifeq ($(WITH_DEBUG_STUB),true)
 include debug_stub/include.mk
 endif

--- a/code/firmware/rosco_m68k_development/main1.c
+++ b/code/firmware/rosco_m68k_development/main1.c
@@ -21,6 +21,9 @@
 #include "system.h"
 #include "serial.h"
 
+#ifdef XOSERA_CON
+#include "xosera.h"
+#endif
 #ifdef VIDEO9958_CON
 #include "video9958.h"
 #endif
@@ -151,11 +154,24 @@ noreturn void main1() {
 
     INSTALL_EASY68K_TRAP_HANDLERS();
 
+#ifdef XOSERA_CON
+    if (HAVE_XOSERA()) {
+        XOSERA_CON_INIT();
+        XOSERA_CON_INSTALLHANDLERS();
+    }
+
+    goto skip9958;
+#endif
+
 #ifdef VIDEO9958_CON
     if (HAVE_V9958()) {
         V9958_CON_INIT();
         V9958_CON_INSTALLHANDLERS();
     }
+#endif
+
+#ifdef XOSERA_CON
+skip9958:
 #endif
 
     // Now we have tick, we can determine CPU speed

--- a/code/firmware/rosco_m68k_development/main1.c
+++ b/code/firmware/rosco_m68k_development/main1.c
@@ -158,9 +158,8 @@ noreturn void main1() {
     if (HAVE_XOSERA()) {
         XOSERA_CON_INIT();
         XOSERA_CON_INSTALLHANDLERS();
+        goto skip9958;
     }
-
-    goto skip9958;
 #endif
 
 #ifdef VIDEO9958_CON

--- a/code/firmware/rosco_m68k_development/videoXosera/include.mk
+++ b/code/firmware/rosco_m68k_development/videoXosera/include.mk
@@ -1,0 +1,2 @@
+EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DXOSERA_CON -IvideoXosera/include
+OBJECTS := $(OBJECTS) videoXosera/xvidcon.o

--- a/code/firmware/rosco_m68k_development/videoXosera/include/xosera.h
+++ b/code/firmware/rosco_m68k_development/videoXosera/include/xosera.h
@@ -1,0 +1,37 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+ *                     |_____|       firmware v2
+ * ------------------------------------------------------------
+ * Copyright (c)2020-2021 Ross Bamford and contributors
+ * See top-level LICENSE.md for licence information.
+ *
+ * Xosera console low-level primitives
+ * ------------------------------------------------------------
+ */
+
+#ifndef __ROSCO_M68K_XOSERA_CON_H
+#define __ROSCO_M68K_XOSERA_CON_H
+
+#include <stdbool.h>
+
+/**
+ * Returns true if a Xosera is installed, false otherwise.
+ */
+bool HAVE_XOSERA();
+
+/**
+ * Initialize the Xosera console.
+ */
+void XOSERA_CON_INIT();
+
+/**
+ * Install handlers for syscall PRINT/PRINTLN
+ */
+void XOSERA_CON_INSTALLHANDLERS();
+
+#endif  //  __ROSCO_M68K_XOSERA_CON_H
+

--- a/code/firmware/rosco_m68k_development/videoXosera/xosera_equates.asm
+++ b/code/firmware/rosco_m68k_development/videoXosera/xosera_equates.asm
@@ -1,0 +1,66 @@
+;------------------------------------------------------------
+;                                  ___ ___ _   
+;  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+; |  _| . |_ -|  _| . |     |     | . | . | '_|
+; |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
+;                     |_____|       software v1 
+;------------------------------------------------------------
+; Copyright (c)2021 Ross Bamford
+; See top-level LICENSE.md for licence information.
+;
+; Equates for Xosera (XVID) by Xark
+;------------------------------------------------------------
+
+;typedef enum logic [3:0] {
+;        // register 16-bit read/write (no side effects)
+;    XVID_AUX_ADDR,          // reg 0: TODO video data (as set by VID_CTRL)
+;    XVID_CONST,             // reg 1: TODO CPU data (instead of read from VRAM)
+;    XVID_RD_ADDR,           // reg 2: address to read from VRAM
+;    XVID_WR_ADDR,           // reg 3: address to write from VRAM
+;
+;        // special registers (with side effects), odd byte write triggers effect
+;    XVID_DATA,              // reg 4: read/write word from/to VRAM RD/WR
+;    XVID_DATA_2,            // reg 5: read/write word from/to VRAM RD/WR (for 32-bit)
+;    XVID_AUX_DATA,          // reg 6: aux data (font/audio)
+;    XVID_COUNT,             // reg 7: TODO blitter "repeat" count/trigger
+;
+;        // write only, 16-bit
+;    XVID_RD_INC,            // reg 9: read addr increment value
+;    XVID_WR_INC,            // reg A: write addr increment value
+;    XVID_WR_MOD,            // reg C: TODO write modulo width for 2D blit
+;    XVID_RD_MOD,            // reg B: TODO read modulo width for 2D blit
+;    XVID_WIDTH,             // reg 8: TODO width for 2D blit
+;    XVID_BLIT_CTRL,         // reg D: TODO
+;    XVID_UNUSED_1,          // reg E: TODO
+;    XVID_UNUSED_2           // reg F: TODO
+
+XVID_BASE         equ   $f80060       ; Xosera base address 
+XVID_AUX_ADDR     equ   $0            ; Aux read address            (RW)
+XVID_CONST        equ   $4            ; CPU Data(?)                 (RW)
+XVID_RD_ADDR      equ   $8            ; VRAM Read Address           (RW)
+XVID_WR_ADDR      equ   $C            ; VRAM Write Address          (RW)
+XVID_DATA         equ   $10           ; VRAM Data (First word)      (RW)
+XVID_DATA_2       equ   $14           ; VRAM Data (Second word)     (RW)
+XVID_AUX_DATA     equ   $18           ; Aux memory/data             (RW)
+XVID_COUNT        equ   $1C           ; Blitter "repeat" count      (RW)
+XVID_RD_INC       equ   $20           ; Read address increment      (WO)
+XVID_WR_INC       equ   $24           ; Write address increment     (WO)
+XVID_RD_MOD       equ   $28           ; Read modulo width           (WO)
+XVID_WR_MOD       equ   $2C           ; Write modulo width          (WO)
+XVID_WIDTH        equ   $30           ; Width for 2D blit           (WO)
+XVID_BLIT_CTRL    equ   $34           ; Blitter control             (WO)
+XVID_UNUSED_1     equ   $38           ; Unused at present           
+XVID_UNUSED_2     equ   $3C           ; Unused at present
+
+XVID_AUX_VID_W_DISPSTART equ $0000    ; display start address
+XVID_AUX_VID_W_TILEWIDTH equ $0001    ; tile line width (usually WIDTH/8)
+XVID_AUX_VID_W_SCROLLXY  equ $0002    ; [10:8] H fine scroll, [3:0] V fine scroll
+XVID_AUX_VID_W_FONTCTRL  equ $0003    ; [9:8] 2KB font bank, [3:0] font height
+XVID_AUX_VID_R_WIDTH     equ $0000    ; display resolution width
+XVID_AUX_VID_R_HEIGHT    equ $0001    ; display resolution height
+XVID_AUX_VID_R_FEATURES  equ $0002    ; [15] = 1 (test)
+XVID_AUX_VID_R_SCANLINE  equ $0003    ; [15] V blank, [14:11] zero [10:0] V line
+XVID_AUX_W_FONT          equ $4000    ; 0x4000-0x5FFF 8K byte font memory (even byte [15:8] ignored)
+XVID_AUX_W_COLORTBL      equ $8000    ; 0x8000-0x80FF 256 word color lookup table (0xXRGB)
+XVID_AUX_W_AUD           equ $C000    ; 0xC000-0x??? TODO (audio registers)
+

--- a/code/firmware/rosco_m68k_development/videoXosera/xvidcon.asm
+++ b/code/firmware/rosco_m68k_development/videoXosera/xvidcon.asm
@@ -60,7 +60,7 @@ XOSERA_CON_INIT::
     ; Clear console data area (Comment this out if not in ROM)
 .CLEARDATA:
     move.l  #CURPOS,A1
-    move.w  #$C80,D1
+    move.w  #$320,D1
     bra.s   .CLEARSTART
 .CLEARLOOP
     move.l  #0,(A1)+

--- a/code/firmware/rosco_m68k_development/videoXosera/xvidcon.asm
+++ b/code/firmware/rosco_m68k_development/videoXosera/xvidcon.asm
@@ -1,0 +1,389 @@
+;------------------------------------------------------------
+;                                  ___ ___ _
+;  ___ ___ ___ ___ ___       _____|  _| . | |_
+; |  _| . |_ -|  _| . |     |     | . | . | '_|
+; |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+;                     |_____|      Xosera Video
+;------------------------------------------------------------
+; Copyright (c)2021 Ross Bamford & contributors
+; See top-level LICENSE.md for licence information.
+;
+; Xosera 106x30 text console.
+;------------------------------------------------------------
+;
+    include "xosera_equates.asm"
+    include "../equates.asm"
+
+LINELENGTH        equ   106      
+LINECOUNT         equ   30
+DISPLAYSIZE       equ   LINELENGTH*LINECOUNT
+DWDISPLAYSIZE     equ   DISPLAYSIZE/4
+CURPOS            equ   $500      ; dword
+DISPLAYSTART      equ   $502      ; dword
+BUFFER            equ   $504      ; 3180 bytes
+                                  ; 16 bytes remaining...
+
+    section .text
+
+; TODO this needs to actually identify Xosera, but works for now.
+HAVE_XOSERA::
+    move.l  A0,-(A7)
+    jsr     INSTALL_TEMP_BERR_HANDLER
+
+    move.l  #XVID_BASE,A0
+    move.b  (XVID_DATA,A0),D0
+
+    tst.b   BERR_FLAG
+    bne.s   .NOXVID
+
+    move.l  #1,D0
+    bra.s   .DONE
+
+.NOXVID
+    clr.l   D0
+    
+.DONE
+    jsr     RESTORE_BERR_HANDLER
+    move.l  (A7)+,A0
+    rts
+
+
+; Initialize the console
+XOSERA_CON_INIT::
+    movem.l D0-D1/A0-A1,-(A7)
+    move.l  #XVID_BASE,A0                   ; Use A0 as port base register
+
+    ori.w   #$0200,SR                         ; No interrupts during init...
+
+    ; TODO Disable display
+
+    ; Clear console data area (Comment this out if not in ROM)
+.CLEARDATA:
+    move.l  #CURPOS,A1
+    move.w  #$C80,D1
+    bra.s   .CLEARSTART
+.CLEARLOOP
+    move.l  #0,(A1)+
+.CLEARSTART
+    dbra.w	D1,.CLEARLOOP
+
+    ; Clear the main memory buffer and copy to the VRAM 
+;    bsr.s   CLEARBUFFER
+    lea     BUFFER,A1
+    clr.b   D0
+    bsr.w   BUFFERFLIP
+
+    ; TODO enable display
+
+    andi.w   #~$0200,SR                       ; Enable interrupts...
+
+    move.l  #SZHEADER,A1
+.PRINTLOOP
+    move.b  (A1)+,D0
+    beq.s   .PRINTDONE
+     
+    bsr.w   XVID_CON_PUTCHAR
+    bra.s   .PRINTLOOP
+.PRINTDONE
+
+    movem.l (A7)+,D0-D1/A0-A1
+    rts
+
+
+; Clear buffer (private)
+;
+; Modifies: D1, A1
+CLEARBUFFER:
+    move.w  #DWDISPLAYSIZE,D1             ; Display size in longwords
+    move.l  #BUFFER,A1
+    bra.s   .ZEROBUF_START
+.ZEROBUF_LOOP:
+    move.l  #0,(A1)+                      ; Clear 4 characters
+.ZEROBUF_START:
+    dbra.w  D1,.ZEROBUF_LOOP
+    rts
+
+
+; Clear the screen
+;
+; Arguments:
+;   None
+;
+; Modifies: 
+;   None
+;
+; This depends on the implementation of CLEARBUFFER (i.e. 
+; the register sizing therein). If that func changes, 
+; this needs to be updated!
+;
+; TODO Maybe there's a more efficient way to do this
+; (rather than doing the whole copy/flip). Look into that.
+XVID_CON_CLRSCR:
+    move.w  D1,-(A7)
+    move.l  A0,-(A7)
+    ori.w   #$0200,SR                      ; Disable interrupts
+    bsr.s   CLEARBUFFER                    ; Clear
+    andi.w  #~$200,SR                      ; And re-enable...
+    move.w  #0,CURPOS
+    move.l  (A7)+,A0
+    move.w  (A7)+,D1
+    
+    ; Now we've cleared, we need to copy the whole buffer and flip
+    lea.l   BUFFER,A1
+    bsr.w   BUFFERFLIP
+    rts
+
+
+XVID_CON_PRINT:
+    move.l  D0,-(A7)
+
+.PRINTLOOP
+    move.b  (A0)+,D0
+    beq.s   .PRINTDONE
+     
+    bsr.w   XVID_CON_PUTCHAR
+    bra.s   .PRINTLOOP
+.PRINTDONE
+
+    move.l  (A7)+,D0
+    rts
+
+XVID_CON_PRINTLN:
+    bsr.s   XVID_CON_PRINT                 ; Print callers message
+    move.l  A0,-(A7)                       ; Stash A0 to restore later
+    
+    lea     SZ_CR,A0                       ; Load CR...
+    bsr.s   XVID_CON_PRINT                 ; ... and print it
+        
+    move.l  (A7)+,A0                       ; Restore A0
+    rts
+
+XVID_CON_SETCURSOR:
+    ; TODO implement this!
+    rts
+
+XOSERA_CON_INSTALLHANDLERS::
+    move.l  #XVID_CON_PRINT,EFP_PRINT
+    move.l  #XVID_CON_PRINTLN,EFP_PRINTLN
+    move.l  #XVID_CON_PUTCHAR,EFP_PRINTCHAR
+    move.l  #XVID_CON_CLRSCR,EFP_CLRSCR
+    move.l  #XVID_CON_SETCURSOR,EFP_SETCURSOR
+    rts
+
+; Internal sub to copy the main memory buffer to
+; VRAM. Used at init and on scroll.
+;
+; Arguments:
+;   A0    Xosera Base  
+;   A1    Main memory buffer
+;
+; Trashes:
+;   Nothing
+;
+BUFFERFLIP:
+    movem.l D0-D2,-(A7)
+    ori.w   #$0200,SR                         ; Cannot be interrupted for a bit...
+
+    ; TODO disable screen
+
+    ; Set up to write VRAM at 0x0
+    clr.w   D1
+    movep.w D1,(XVID_WR_ADDR,A0)            ; Setup VRAM write
+    
+.GOGOGO    
+    move.w  DISPLAYSTART,D0
+    move.w  #DISPLAYSIZE,D1
+
+    bra.s   .COPY
+.COPYLOOP
+    clr.w   D2
+    move.b  (A1,D0),D2
+    or.w    #$0A00,D2
+    movep.w D2,(XVID_DATA,A0)
+    addq.w  #1,D0
+    cmpi.w  #DISPLAYSIZE,D0
+    bne.s   .COPY
+
+    moveq.l #0,D0
+  
+.COPY
+    dbra.w  D1,.COPYLOOP  
+
+    ; TODO re-enable screen
+
+    andi.w  #~$0200,SR                        ; Go for interrupts again...
+    movem.l (A7)+,D0-D2
+    rts
+
+
+; Internal - Translate the buffer position in D1.W into the relevant
+; VRAM position based on the setting of CURRENTPAGE and the
+; current display start (in D2.W) , and set up Xosera for a VRAM 
+; write there.
+;
+; Interrupts should be disabled while this happens!
+;
+; Arguments:
+;   A0      Xosera base address
+;   D1.W    Buffer position (CURPOS)
+;   D2.W    Display start position (DISPLAYSTART)
+;
+; Modifies:
+;   Xosera Registers
+;
+SETUP_VRAM_WRITE:
+    move.w  D3,-(A7)
+ 
+    ; Write this character to the current VRAM page too
+    move.w  D1,D3
+    sub.w   D2,D3
+    bge.s   .WRITEVRAM
+
+    ; Negative, add display size
+    addi.w  #DISPLAYSIZE,D3
+
+.WRITEVRAM
+    movep.w D3,(XVID_WR_ADDR,A0)       ; Setup VRAM write
+    move.w  (A7)+,D3
+    rts
+
+
+; Put a character to the screen
+;
+; Arguments:
+;   D0.B  The character
+;
+; Modifies
+;   D0.B  Possibly trashed
+;
+; Register alloc in function:
+;   A0    Xosera base
+;   A1    Buffer
+;   D1.W  CURPOS (buffer pointer)
+;   D2.W  DISPLAYSTART (start pointer)
+; 
+XVID_CON_PUTCHAR::
+    ; Ignoring linefeeds (for legacy compatibility)
+    cmp.b   #10,D0
+    bne.s   .NOTIGNORED
+  
+    rts
+
+.NOTIGNORED
+    movem.l D1-D2/A0-A1,-(A7)
+    
+    move.l  #XVID_BASE,A0               ; Use A0 as Xosera base
+    move.w  CURPOS,D1                     ; Load current pointer
+ 
+    ; Is this a carriage-return?
+    cmp.b   #13,D0
+    bne.s   .NOTCR
+
+    ; Yes - handle CR
+    clr.l   D2                            ; Find how far until start
+    move.w  D1,D2                         ; of next line.
+    divu.w  #LINELENGTH,D2                ; d1 = LINELENGTH - d1 % LINELENGTH                 
+    swap    D2
+    move.w  #LINELENGTH,D1
+    sub.w   D2,D1
+
+    move.b  #0,D0                         ; Recursively clear to EOL
+    bra.s   .CLREOL                       ; (TODO Non-recursive would be faster...)
+.CLREOL_LOOP
+    bsr.s   XVID_CON_PUTCHAR
+.CLREOL
+    dbra.w  D1,.CLREOL_LOOP
+
+    bra.w   .DONE
+.NOTCR
+    ; No, is it a backspace?
+    cmp.b    #8,D0
+    bne.s   .NOTBS
+
+    ; Yes - handle backspace
+    lea.l   BUFFER,A1                     ; Get buffer
+    move.w  DISPLAYSTART,D2               ; Load start of display pointer
+    cmp.w   D1,D2                         ; Are we at display start?
+    beq.w   .DONE                         ; Yes - Ignore BS
+
+    ori.w   #$0200,SR                     ; Disable interrupts for a sec
+    subq.w  #1,D1                         ; Back a space
+
+    bsr.w   SETUP_VRAM_WRITE              ; Clear from VRAM
+
+    move.w  #$0A20,D0
+    movep.w D0,(XVID_DATA,A0)             ; Overwrite character
+
+    andi.w  #~$0200,SR                    ; Go ahead with the interrupts...
+    move.b  #0,(A1,D1)                    ; Clear from buffer
+    move.w  D1,CURPOS                     ; Store new position
+
+    andi.w  #~$0200,SR
+    bra.w   .DONE
+
+.NOTBS
+    ; No - Just print
+    lea.l   BUFFER,A1                     ; Get buffer
+    move.w  DISPLAYSTART,D2               ; And current DISPLAYSTART
+    
+    move.b  D0,(A1,D1)                    ; Buffer this character
+
+.WRITEVRAM
+    ori.w   #$0200,SR                     ; No interrupts for a sec...
+    bsr.w   SETUP_VRAM_WRITE              ; Setup to write to correct position for D2
+
+    and.w   #$00FF,D0
+    or.w    #$0A00,D0
+    movep.w D0,(XVID_DATA,A0)             ; And write,
+    andi.w  #~$0200,SR                    ; Go ahead with the interrupts...
+    
+    addq.w  #1,D1
+
+    cmp.w   #DISPLAYSIZE,D1               ; Are we at end of buffer?
+    bne.s   .CHECKSCROLL                  ; Nope, go to check scroll
+
+    move.w  #0,D1                         ; Yep, reset pointer
+
+.CHECKSCROLL
+    move.w  D1,CURPOS                     ; Store new pointer
+    
+    cmp.w   D2,D1                         ; Wrapped back to start of display?
+    bne.s   .DONE                         ; Nope, we're done
+
+    ; Let's do some scrolling...
+    addi.w  #LINELENGTH,D2                ; Scroll...
+    cmp.w   #DISPLAYSIZE,D2               ; Reached end of the buffer?
+    bne.s   .STORESTART                   ; Nope - on we go...
+
+    move.w  #0,D2                         ; Yes - wrap around
+
+.STORESTART
+    move.w  D2,DISPLAYSTART               ; Save new start so we can reuse D2
+
+    ; Clear the line...
+    adda.l  D1,A1                         ; Point to start of line
+    move.w  #LINELENGTH,D2                ; Counter is line length
+    bra.s   .CLEARLINE
+.CLEARLINE_LOOP
+    move.b  #0,(A1)+                      ; Clear character
+.CLEARLINE
+    dbra.w  D2,.CLEARLINE_LOOP
+
+    ; Now we've scrolled, we need to copy the whole buffer and flip
+    lea.l   BUFFER,A1
+    bsr.w   BUFFERFLIP
+
+.DONE
+    movem.l (A7)+,D1-D2/A0-A1
+    rts
+
+    section .rodata
+SZHEADER      dc.b    "                                ___ ___ _",13
+              dc.b    " ___ ___ ___ __ ___       _____|  _| . | |_",13
+              dc.b    "|  _| . |_ -| _| . |     |     | . | . | '_|",13
+              dc.b    "|_| |___|___|__|___|_____|_|_|_|___|___|_,_|",13
+              dc.b    "Xosera v0.12       |_____|  Firmware 2.0.DEV",13
+              dc.b    13,13, 0
+SZ_CR         dc.b    $D, 0
+
+


### PR DESCRIPTION
This PR adds the initial cut of the Xosera text console in firmware.

* Console is quite "rough and ready" at the moment, but in testing it works well
* No advantage is taken of advanced Xosera features yet, but we can iterate on this.
* Colour is not currently supported (without direct VRAM access).
* Xosera console takes precedent over V9958 (in the unlikely event that both are present).

Proof of life:

![image](https://user-images.githubusercontent.com/2096421/118026870-3d7d1180-b359-11eb-8d72-289dbbcc6fee.png)
