### PR TITLE
Fix firmware SD get_card_type(), checking echo-back

### DIFF
--- a/code/firmware/rosco_m68k_development/blockdev/bbsd.c
+++ b/code/firmware/rosco_m68k_development/blockdev/bbsd.c
@@ -377,13 +377,12 @@ static BBSDCardType get_card_type() {
         BBSPI_recv_byte();
         BBSPI_recv_byte();
         BBSPI_recv_byte();
-        BBSPI_recv_byte();
         uint8_t result = BBSPI_recv_byte();
 
         if (result == 0xAA) {
-            return BBSD_CARD_TYPE_UNKNOWN;
-        } else {
             return BBSD_CARD_TYPE_V2;
+        } else {
+            return BBSD_CARD_TYPE_UNKNOWN;
         }
     }
 }

--- a/code/firmware/rosco_m68k_v1.2/stage2/sdfat/bbsd.c
+++ b/code/firmware/rosco_m68k_v1.2/stage2/sdfat/bbsd.c
@@ -370,13 +370,12 @@ static BBSDCardType get_card_type(BBSPI *spi) {
         BBSPI_recv_byte(spi);
         BBSPI_recv_byte(spi);
         BBSPI_recv_byte(spi);
-        BBSPI_recv_byte(spi);
         uint8_t result = BBSPI_recv_byte(spi);
 
         if (result == 0xAA) {
-            return BBSD_CARD_TYPE_UNKNOWN;
-        } else {
             return BBSD_CARD_TYPE_V2;
+        } else {
+            return BBSD_CARD_TYPE_UNKNOWN;
         }
     }
 }

--- a/code/firmware/rosco_m68k_v1.3/sdcard/bbsd.c
+++ b/code/firmware/rosco_m68k_v1.3/sdcard/bbsd.c
@@ -376,13 +376,12 @@ static BBSDCardType get_card_type() {
         BBSPI_recv_byte();
         BBSPI_recv_byte();
         BBSPI_recv_byte();
-        BBSPI_recv_byte();
         uint8_t result = BBSPI_recv_byte();
 
         if (result == 0xAA) {
-            return BBSD_CARD_TYPE_UNKNOWN;
-        } else {
             return BBSD_CARD_TYPE_V2;
+        } else {
+            return BBSD_CARD_TYPE_UNKNOWN;
         }
     }
 }


### PR DESCRIPTION
The existing code reads the full 32 bits of the extra part of the R7, then checks the next byte against the check pattern, `0xAA`. Instead it should read 3 bytes, and check the 4th byte read against `0xAA`.

If the check pattern is `0xAA`, that means that the card is compatible and V2 or greater. Currently, if the pattern is `0xAA`, the card's version is detected as unknown. This hasn't been a problem because that byte will end up being a dummy `0xFF`, after the real response has been read. It would only be one if the card wasn't correctly echoing the check pattern, but the firmware would see it as correct.

Previously:
```
---+----+----+
...|0xAA|0xFF|
---+----+----+
          ^
          |
          +-+
            |
Check that this isn't 0xAA for SD V2
```

Now:
```
---+----+
...|0xAA|
---+----+
      ^
      |
      +-----+
            |
Check that this is 0xAA for SD V2
```

I've checked that the SD card still works, at least with the cheap SDHC I have, in `rosco_m68k_v1.3`. I haven't tested in `rosco_m68k_v1.2` because I don't have an r1.2 board, or in `rosco_m68k_development` because I don't (yet) have a bigrom-modded board. The changes are however the same in the three folders.