### PR TITLE
Don't enable video interrupts at end of bootstrap

### DIFF
--- a/code/firmware/rosco_m68k_development/bootstrap.asm
+++ b/code/firmware/rosco_m68k_development/bootstrap.asm
@@ -92,7 +92,7 @@ START::
     bsr.s   PRINT_BANNER
 
     bclr.b  #1,MFP_GPDR               ; Turn on GPIO #1 (Red LED)  
-    and.w   #$F0FF,SR                 ; Enable interrupts
+    and.w   #$F2FF,SR                 ; Enable interrupts (except video)
 
     jmp     linit                     ; Init C land, calls through to main1
 


### PR DESCRIPTION
Instead of setting interrupt mask to `0` at the end of the bootstrap, this change sets it to `2`, meaning interrupts 1 and 2 (reserved for video cards) remain disabled. Later code sets it back to two anyway, this change just avoids the issue where it is 0 for a brief time, causing starvation if there is a video card installed that requires software interrupt acknowledgement to drop its IRQ line.