### PR TITLE
Band-aid for lib build order (again).

### DIFF
--- a/code/software/libs/Makefile
+++ b/code/software/libs/Makefile
@@ -39,8 +39,8 @@ include src/debug_stub/include.mk
 include src/start_serial/include.mk
 include src/vterm/include.mk
 include src/libm/include.mk
-include src/printf/include.mk
 include src/sst_flash/include.mk
+include src/printf/include.mk
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $<


### PR DESCRIPTION
Will look at a proper fix for this going forward. I suspect it's because
we're misusing included partial makefiles a bit.