### PR TITLE
Direct EASy68K `SEND_CHAR` to console, not UART

### DIFF
--- a/code/firmware/rosco_m68k_development/easy68k/syscalls_asm.asm
+++ b/code/firmware/rosco_m68k_development/easy68k/syscalls_asm.asm
@@ -239,7 +239,7 @@ READ_CHAR:
 * ************************************************************************** *
 SEND_CHAR:
     move.l  D1,D0                       ; Platform code expects arg in D0...
-    bsr.w   SENDCHAR
+    bsr.w   FW_PRINTCHAR
     bra.w   EPILOGUE                   
 
 


### PR DESCRIPTION
`TRAP #15` function `#6` now calls `FW_PRINTCHAR` instead of directly calling `SENDCHAR`. Previously, this one specific function wouldn't print to an attached display, instead always printing to the default UART. It will now print to the default console, matching functions `#0`, `#1`, `#3`, etc.

Fixes #240 