### PR TITLE
Add version info and flag check to flash update utility

### DIFF
--- a/code/firmware/rosco_m68k_development/Makefile
+++ b/code/firmware/rosco_m68k_development/Makefile
@@ -46,6 +46,7 @@ WITH_DEBUG_STUB?=true
 ifeq ($(HUGEROM),true)
 LDFLAGS:=-T ./rosco_m68k_firmware_1M.ld
 ROMDEVICE=SST39SF040
+DEFINES:=$(DEFINES) -DHUGEROM
 else
 LDFLAGS:=-T ./rosco_m68k_firmware_64k.ld
 endif

--- a/code/firmware/rosco_m68k_development/rosco_m68k_private.asm
+++ b/code/firmware/rosco_m68k_development/rosco_m68k_private.asm
@@ -15,10 +15,15 @@
 ; MSW is flags, LSW is split into major (MSB) and minor (LSB)
 ;
 ; Flags:
-; bit 0 - 13: Reserved
+; bit 0 - 12: Reserved
+; bit 13    : Flashable ROM (i.e. HUGEROM).
 ; bit 14    : Requires larger system data area
 ; bit 15    : Snapshot version
-RELEASE_VER     equ     $80000200
+  ifd HUGEROM
+RELEASE_VER     equ     $E0000200
+  else
+RELEASE_VER     equ     $C0000200
+  endif
 
 VEC_LIMIT       equ     $400
 

--- a/code/software/libs/src/machine/include/machine.h
+++ b/code/software/libs/src/machine/include/machine.h
@@ -74,6 +74,18 @@
 #endif
 
 /*
+ * The firmware contains a RomVersionInfo at _FIRMWARE_REV.
+ */
+typedef struct {
+    bool is_snapshot: 1;
+    bool is_extdata: 1;
+    bool is_huge: 1;
+    uint16_t reserved: 13;
+    uint8_t major;
+    uint8_t minor;
+} __attribute__((packed)) RomVersionInfo;
+
+/*
  * The SystemDataBlock is a global reserved structure at _SDB.
  */
 typedef struct {


### PR DESCRIPTION
This change adds a new flag to the version flags in the firmware to indicate that the firmware is built as a (flashable) HUGEROM. Adding this after forgetting to build with HUGEROM one too many times, and flashing ROMs that wouldn't work.
A check is added to the update flash utility to check for this flag.

* Add version flag for HUGEROM builds
* Correctly set "Requires extended data area" flag in development ROMs
* Add `RomVersionInfo` to `machine.h` to allow versions to be checked easily
* Add check in `updateflash` to check version in the loaded ROM before flashing.