### PR TITLE
Add NO_TICK option to disable MFP interrupts

### DIFF
--- a/code/firmware/rosco_m68k_development/Makefile
+++ b/code/firmware/rosco_m68k_development/Makefile
@@ -59,6 +59,10 @@ ifeq ($(ATA_DEBUG),true)
 DEFINES:=$(DEFINES) -DATA_DEBUG
 endif
 
+ifeq ($(NO_TICK),true)
+DEFINES:=$(DEFINES) -DNO_TICK
+endif
+
 include easy68k/include.mk
 include blockdev/include.mk
 

--- a/code/firmware/rosco_m68k_development/bootstrap.asm
+++ b/code/firmware/rosco_m68k_development/bootstrap.asm
@@ -90,7 +90,12 @@ START::
     bsr.w   INITMEMCOUNT              ; Initialise memory count in SDB    
     bsr.s   PRINT_BANNER
 
-    bclr.b  #1,MFP_GPDR               ; Turn on GPIO #1 (Red LED)  
+    ifd NO_TICK
+    bset.b  #1,MFP_GPDR               ; Turn off GPIO #1 (Red LED) as no tick to reset it later..
+    else
+    bclr.b  #1,MFP_GPDR               ; Turn on GPIO #1 (Red LED)
+    endif
+
     and.w   #$F2FF,SR                 ; Enable interrupts (except video)
   
     jmp     linit                     ; Init C land, calls through to main1
@@ -270,7 +275,13 @@ INITMFP:
     ; Timer setup - Timer D controls serial clock, C is kernel tick
     move.b  #$B8,MFP_TCDR             ; Timer C count is 184 for 50Hz (interrupt on rise and fall so 100Hz)
     move.b  #$03,MFP_TDDR             ; Timer D count is 3 for 307.2KHz, divided to 9600 baud
+
+    ifd NO_TICK
     move.b  #$71,MFP_TCDCR            ; Enable timer C with /200 and D with /4 prescaler
+    else
+    move.b  #$01,MFP_TCDCR            ; Enable timer C with /200 and D with /4 prescaler
+    endif
+
     
     ; USART setup
     move.b  #$88,MFP_UCR              ; /16 clock, async, 8N1
@@ -280,8 +291,12 @@ INITMFP:
     move.l  #MFP_VECBASE,D0           ; Set up the base MFP vector at 0x40 (first 16 user vectors)...
     or.l    #8,D0                     ; ... and set software-end-of-interrupt mode
     move.b  D0,MFP_VR                 ; ... then write to MFP vector register
+
+    ifd NO_TICK
+    bset.b  #0,MFP_GPDR               ; Turn off GPIO #0 (Green LED)
+    else
     or.b    #$20,MFP_IERB             ; Enable Timer C interrupt, but leave it masked for now
-                                      ; (kmain will call START_HEART later)
+    endif
    
     move.l  #MFPBASE,SDB_UARTBASE     ; Default UART starts out as MFP, may get overwritten later... 
     ; Indicate success and return

--- a/code/firmware/rosco_m68k_development/bootstrap.asm
+++ b/code/firmware/rosco_m68k_development/bootstrap.asm
@@ -277,9 +277,9 @@ INITMFP:
     move.b  #$03,MFP_TDDR             ; Timer D count is 3 for 307.2KHz, divided to 9600 baud
 
     ifd NO_TICK
-    move.b  #$71,MFP_TCDCR            ; Enable timer C with /200 and D with /4 prescaler
+    move.b  #$01,MFP_TCDCR            ; Disable timer C and enable timer D with /4 prescaler
     else
-    move.b  #$01,MFP_TCDCR            ; Enable timer C with /200 and D with /4 prescaler
+    move.b  #$71,MFP_TCDCR            ; Enable timer C with /200 and D with /4 prescaler
     endif
 
     

--- a/code/firmware/rosco_m68k_development/main1.c
+++ b/code/firmware/rosco_m68k_development/main1.c
@@ -150,7 +150,9 @@ noreturn void main1() {
     }
 
     // Start the timer tick
+#ifndef NO_TICK
     START_HEART();
+#endif
 
     INSTALL_EASY68K_TRAP_HANDLERS();
 
@@ -173,7 +175,12 @@ skip9958:
 #endif
 
     // Now we have tick, we can determine CPU speed
+#ifdef NO_TICK
+    sdb->cpu_speed = 0;
+#else
     sdb->cpu_speed = cpuspeed(sdb->cpu_model);
+#endif
+
     print_cpu_mem_info();
 
 #ifdef BLOCKDEV_SUPPORT


### PR DESCRIPTION
For advanced testing (currently with Xosera), this adds an option to completely disable the system timer tick (and thus, MFP interrupts under firmware control).

This is primarily to work around the known issue with MFP IACK on r1.x boards, but may be generally useful for other things too.