### PR TITLE
Fix #251

### DIFF
--- a/code/software/2dmaze/Makefile
+++ b/code/software/2dmaze/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -15,8 +17,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) -I$(SYSINCDIR)/easy68k	\
 			 -mcpu=68010 -march=68010 -mtune=68010														\
 			 -mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) -L$(SYSLIBDIR)/easy68k  \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -L$(SYSLIBDIR)/easy68k -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/68010-test/Makefile
+++ b/code/software/68010-test/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 DEFINES=
 SYSINCDIR?=../libs/build/include
@@ -11,8 +13,14 @@ LIBS=-lgpio -lmachine -lstart_serial
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror									\
 				-I$(SYSINCDIR) -mcpu=68010 -march=68010 -mtune=68010						\
 				-mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/README.md
+++ b/code/software/README.md
@@ -82,6 +82,12 @@ There is a short `README.md` in each program directory that contains
 documentation specific to that program - see those for detailes of the
 program and any specific build instructions.
 
+> **Note** if your rosco_m68k has the flash ROM adapter and is 
+running a `HUGEROM` build of the firmware, you will need to build the
+examples with `ROSCO_M68K_HUGEROM` set to `true`, e.g. by passing on
+the command line (`ROSCO_M68K_HUGEROM=true make clean all`) or by
+setting an environment variable for a more permanent solution.
+
 ## Building your own projects
 
 There are some template starter projects available in `../starter_projects`,

--- a/code/software/adventure/Makefile
+++ b/code/software/adventure/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 CPU?=68010
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
@@ -16,8 +18,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -pedantic -Werror		\
 				-I$(SYSINCDIR) -mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU)						\
 				-mno-align-int -mno-strict-align -fomit-frame-pointer $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/bbsd/Makefile
+++ b/code/software/bbsd/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O2 -fomit-frame-pointer
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -18,8 +20,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lcstdlib -lprintf-softfloat -lmachine -lstart_serial -lgpio -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-		-Map=$(MAP) --gc-sections --oformat=elf32-m68k
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/software/dhrystone/Makefile
+++ b/code/software/dhrystone/Makefile
@@ -5,6 +5,8 @@
 
 # Hacked by Xark for dhrystone
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 CPU?=68010
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
@@ -19,8 +21,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs                                  \
     | sed 's/libraries: =/-L/g'                                             \
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lprintf -lcstdlib -lmachine -lstart_serial -lgcc
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR)     \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/easy68k-demo/Makefile
+++ b/code/software/easy68k-demo/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -11,8 +13,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -pedantic -Werror		\
 				-I$(SYSINCDIR) -mcpu=68010 -march=68010 -mtune=68010						\
 				-mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR)  \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/exception_tests/Makefile
+++ b/code/software/exception_tests/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -15,8 +17,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
 			 -mcpu=68010 -march=68010 -mtune=68010 -fomit-frame-pointer				\
 			 -mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/flashrom/Makefile
+++ b/code/software/flashrom/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c) 2020 Xark
 # MIT LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
 SYSINCDIR?=../libs/build/include
@@ -17,8 +19,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lprintf -lcstdlib -lmachine -lstart_serial -lgcc -lsst_flash
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/software/gpio-interrupt/Makefile
+++ b/code/software/gpio-interrupt/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Xark
 # MIT LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -Os -fomit-frame-pointer
 DEFINES=
 SYSINCDIR?=../libs/build/include
@@ -12,8 +14,15 @@ CFLAGS=-std=c11 -ffreestanding -ffunction-sections -fdata-sections \
 				-Wall -Wextra -Werror -pedantic -I$(SYSINCDIR) \
 				-mcpu=68010 -march=68010 -mtune=68010 $(DEFINES)
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP) --gc-sections --oformat=elf32-m68k --defsym=_RAM_SIZE=1M
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections   \
+		--oformat=elf32-m68k --defsym=_RAM_SIZE=1M
 VASMFLAGS=-Felf -m68010 -quiet -Lnf -showopt $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/software/gpiodemo/Makefile
+++ b/code/software/gpiodemo/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 DEFINES=
 SYSINCDIR?=../libs/build/include
@@ -11,8 +13,14 @@ LIBS=-lgpio -lmachine -lstart_serial
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror									\
 				-I$(SYSINCDIR) -mcpu=68010 -march=68010 -mtune=68010						\
 				-mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/lcd-ili9341/Makefile
+++ b/code/software/lcd-ili9341/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Xark
 # MIT LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O3 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
 SYSINCDIR?=../libs/build/include
@@ -17,7 +19,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) \
 				-Map=$(MAP) --gc-sections --oformat=elf32-m68k --defsym=_RAM_SIZE=1M
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/software/libm-test/Makefile
+++ b/code/software/libm-test/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -15,8 +17,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
 			 -mcpu=68010 -march=68010 -mtune=68010														\
 			 -mno-align-int -mno-strict-align -msoft-float $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/life/Makefile
+++ b/code/software/life/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include 
 SYSLIBDIR?=../libs/build/lib
@@ -15,8 +17,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) -I../libs/build/include/easy68k 	\
 			 -mcpu=68010 -march=68010 -mtune=68010														\
 			 -mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) -L ../libs/build/lib/easy68k \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -L ../libs/build/lib/easy68k -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/markm-ide/fat_format/Makefile
+++ b/code/software/markm-ide/fat_format/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c) 2020 Xark
 # MIT LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
 SYSINCDIR?=../../libs/build/include
@@ -17,8 +19,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -ldebug_stub -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/software/markm-ide/hdfat_menu/Makefile
+++ b/code/software/markm-ide/hdfat_menu/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c) 2020 Xark
 # MIT LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
 SYSINCDIR?=../../libs/build/include
@@ -18,8 +20,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -ldebug_stub -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/software/markm-ide/lowlevel/Makefile
+++ b/code/software/markm-ide/lowlevel/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c) 2020 Xark
 # MIT LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
 SYSINCDIR?=../../libs/build/include
@@ -20,8 +22,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -ldebug_stub -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/software/memcheck/Makefile
+++ b/code/software/memcheck/Makefile
@@ -3,11 +3,13 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
 LIBS=-lprintf -lcstdlib -lmachine -lstart_serial -lgcc
-ifeq ($(HUGE),true)
+ifeq ($(ROSCO_M68K_HUGEROM),true)
 LINK_SCRIPT=hugerom_rosco_m68k_program.ld
 else
 LINK_SCRIPT=rosco_m68k_program.ld

--- a/code/software/newserial/Makefile
+++ b/code/software/newserial/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -11,7 +13,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
 			 -mcpu=68010 -march=68010 -mtune=68010 -fomit-frame-pointer				\
 			 -mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) \
 				-Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/software/sdfat_demo/Makefile
+++ b/code/software/sdfat_demo/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -15,8 +17,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
 			 -mcpu=68010 -march=68010 -mtune=68010 -Wno-unused-function				\
 			 -mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/sdfat_menu/Makefile
+++ b/code/software/sdfat_menu/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c) 2020 Xark
 # MIT LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
 SYSINCDIR?=../libs/build/include
@@ -17,7 +19,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) \
 				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/software/updateflash/Makefile
+++ b/code/software/updateflash/Makefile
@@ -1,7 +1,9 @@
-# Make rosco_m68k example programs
+# N.B. This example is HUGEROM-only
 #
 # Copyright (c) 2020 Xark
 # MIT LICENSE
+
+-include $(ROSCO_M68K_DIR)/user.mk
 
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
@@ -17,7 +19,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -lgcc -lsst_flash
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
+LDFLAGS=-T $(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld -L $(SYSLIBDIR) \
 				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/software/vterm/Makefile
+++ b/code/software/vterm/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=
 SYSINCDIR?=../libs/build/include
 SYSLIBDIR?=../libs/build/lib
@@ -15,8 +17,14 @@ DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
 			 -mcpu=68010 -march=68010 -mtune=68010														\
 			 -mno-align-int -mno-strict-align $(DEFINES)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP)
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP)
 ASFLAGS=-Felf -m68010 -quiet $(DEFINES)
 CC=m68k-elf-gcc
 LD=m68k-elf-ld

--- a/code/software/warmboot/Makefile
+++ b/code/software/warmboot/Makefile
@@ -3,6 +3,8 @@
 # Copyright (c)2020 Ross Bamford
 # See LICENSE
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 EXTRA_CFLAGS?=-g -O0 -fomit-frame-pointer
 #EXTRA_VASMFLAGS?=-showopt
 SYSINCDIR?=../libs/build/include
@@ -17,7 +19,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lprintf -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) \
 				-Map=$(MAP) --gc-sections --oformat=elf32-m68k --defsym=_RAM_SIZE=1M
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/starter_projects/starter_asm/Makefile
+++ b/code/starter_projects/starter_asm/Makefile
@@ -7,6 +7,8 @@ ifndef ROSCO_M68K_DIR
 $(error Please set ROSCO_M68K_DIR to the top-level rosco_m68k directory to use for rosco_m68k building)
 endif
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 CPU?=68010
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 SYSINCDIR?=$(ROSCO_M68K_DIR)/code/software/libs/build/include
@@ -21,8 +23,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as

--- a/code/starter_projects/starter_c/Makefile
+++ b/code/starter_projects/starter_c/Makefile
@@ -7,6 +7,8 @@ ifndef ROSCO_M68K_DIR
 $(error Please set ROSCO_M68K_DIR to the top-level rosco_m68k directory to use for rosco_m68k building)
 endif
 
+-include $(ROSCO_M68K_DIR)/user.mk
+
 CPU?=68010
 EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 SYSINCDIR?=$(ROSCO_M68K_DIR)/code/software/libs/build/include
@@ -21,8 +23,14 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
-LDFLAGS=-T $(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld -L $(SYSLIBDIR) \
-				-Map=$(MAP) --gc-sections --oformat=elf32-m68k
+
+ifeq ($(ROSCO_M68K_HUGEROM),true)
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
+else
+LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld
+endif
+
+LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
 AS=m68k-elf-as


### PR DESCRIPTION
* Add support for a new `ROSCO_M68K_HUGEROM` environment variable in all examples and starter projects
* Add ability to include a user makefile from `ROSCO_M68K_DIR/user.mk` with per-user options
* Software `README.md` updated