### PR TITLE
Remove libs `mno-align-int` and `mno-strict-align` options

### DIFF
--- a/code/software/libs/Makefile
+++ b/code/software/libs/Makefile
@@ -9,7 +9,7 @@ DEFINES:=$(DEFINES) -DROSCO_M68K_SYSLIBS
 CFLAGS=-std=c11 -ffreestanding -ffunction-sections -fdata-sections \
 				-nostartfiles -Wall -pedantic -Werror              \
 				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU)           \
-				-mno-align-int -mno-strict-align $(DEFINES)
+				$(DEFINES)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 ARFLAGS=
 CC=m68k-elf-gcc


### PR DESCRIPTION
Removes the `mno-align-int` and `mno-strict-align` options from the libraries Makefile. 

Taking a look at the GCC source, `mno-align-int` (16-bit alignment) is already the default case, so it wasn't doing anything. While `malign-int` does improve performance on 32-bit-bus models, it's documented as an ABI-breaking option since it changes the usual structure alignment/padding.

`mno-strict-align` ignores the alignment requirements, and causes the crashes observed in #253. In all types except Coldfire, `mstrict-align` is the default, and is what we want.

For non-crashing ABI-conforming code, we don't want either of these options.

Fixes #253 