### PR TITLE
Feature/printf fmt warn

### DIFF
--- a/code/firmware/rosco_m68k_development/videoXosera/xosera_equates.asm
+++ b/code/firmware/rosco_m68k_development/videoXosera/xosera_equates.asm
@@ -1,66 +1,99 @@
-;------------------------------------------------------------
-;                                  ___ ___ _   
-;  ___ ___ ___ ___ ___       _____|  _| . | |_ 
-; |  _| . |_ -|  _| . |     |     | . | . | '_|
-; |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
-;                     |_____|       software v1 
-;------------------------------------------------------------
-; Copyright (c)2021 Ross Bamford
-; See top-level LICENSE.md for licence information.
-;
-; Equates for Xosera (XVID) by Xark
-;------------------------------------------------------------
+; 
+;  vim: set et ts=8 sw=4
+; ------------------------------------------------------------
+;   __ __
+;  |  |  |___ ___ ___ ___ ___
+;  |-   -| . |_ -| -_|  _| .'|
+;  |__|__|___|___|___|_| |__,|
+; 
+;  Xark's Open Source Enhanced Retro Adapter
+; 
+;  - "Not as clumsy or random as a GPU, an embedded retro
+;     adapter for a more civilized age."
+; 
+;  ------------------------------------------------------------
+;  Copyright (c) 2021 Xark
+;  MIT License
+; 
+;  Xosera rosco_m68k asm register definition header file
+;  ------------------------------------------------------------
 
-;typedef enum logic [3:0] {
-;        // register 16-bit read/write (no side effects)
-;    XVID_AUX_ADDR,          // reg 0: TODO video data (as set by VID_CTRL)
-;    XVID_CONST,             // reg 1: TODO CPU data (instead of read from VRAM)
-;    XVID_RD_ADDR,           // reg 2: address to read from VRAM
-;    XVID_WR_ADDR,           // reg 3: address to write from VRAM
-;
-;        // special registers (with side effects), odd byte write triggers effect
-;    XVID_DATA,              // reg 4: read/write word from/to VRAM RD/WR
-;    XVID_DATA_2,            // reg 5: read/write word from/to VRAM RD/WR (for 32-bit)
-;    XVID_AUX_DATA,          // reg 6: aux data (font/audio)
-;    XVID_COUNT,             // reg 7: TODO blitter "repeat" count/trigger
-;
-;        // write only, 16-bit
-;    XVID_RD_INC,            // reg 9: read addr increment value
-;    XVID_WR_INC,            // reg A: write addr increment value
-;    XVID_WR_MOD,            // reg C: TODO write modulo width for 2D blit
-;    XVID_RD_MOD,            // reg B: TODO read modulo width for 2D blit
-;    XVID_WIDTH,             // reg 8: TODO width for 2D blit
-;    XVID_BLIT_CTRL,         // reg D: TODO
-;    XVID_UNUSED_1,          // reg E: TODO
-;    XVID_UNUSED_2           // reg F: TODO
+; See: https://github.com/XarkLabs/Xosera/blob/master/REFERENCE.md
 
-XVID_BASE         equ   $f80060       ; Xosera base address 
-XVID_AUX_ADDR     equ   $0            ; Aux read address            (RW)
-XVID_CONST        equ   $4            ; CPU Data(?)                 (RW)
-XVID_RD_ADDR      equ   $8            ; VRAM Read Address           (RW)
-XVID_WR_ADDR      equ   $C            ; VRAM Write Address          (RW)
-XVID_DATA         equ   $10           ; VRAM Data (First word)      (RW)
-XVID_DATA_2       equ   $14           ; VRAM Data (Second word)     (RW)
-XVID_AUX_DATA     equ   $18           ; Aux memory/data             (RW)
-XVID_COUNT        equ   $1C           ; Blitter "repeat" count      (RW)
-XVID_RD_INC       equ   $20           ; Read address increment      (WO)
-XVID_WR_INC       equ   $24           ; Write address increment     (WO)
-XVID_RD_MOD       equ   $28           ; Read modulo width           (WO)
-XVID_WR_MOD       equ   $2C           ; Write modulo width          (WO)
-XVID_WIDTH        equ   $30           ; Width for 2D blit           (WO)
-XVID_BLIT_CTRL    equ   $34           ; Blitter control             (WO)
-XVID_UNUSED_1     equ   $38           ; Unused at present           
-XVID_UNUSED_2     equ   $3C           ; Unused at present
+XM_BASEADDR     equ     $f80060     ; Xosera rosco_m68k register base address
 
-XVID_AUX_VID_W_DISPSTART equ $0000    ; display start address
-XVID_AUX_VID_W_TILEWIDTH equ $0001    ; tile line width (usually WIDTH/8)
-XVID_AUX_VID_W_SCROLLXY  equ $0002    ; [10:8] H fine scroll, [3:0] V fine scroll
-XVID_AUX_VID_W_FONTCTRL  equ $0003    ; [9:8] 2KB font bank, [3:0] font height
-XVID_AUX_VID_R_WIDTH     equ $0000    ; display resolution width
-XVID_AUX_VID_R_HEIGHT    equ $0001    ; display resolution height
-XVID_AUX_VID_R_FEATURES  equ $0002    ; [15] = 1 (test)
-XVID_AUX_VID_R_SCANLINE  equ $0003    ; [15] V blank, [14:11] zero [10:0] V line
-XVID_AUX_W_FONT          equ $4000    ; 0x4000-0x5FFF 8K byte font memory (even byte [15:8] ignored)
-XVID_AUX_W_COLORTBL      equ $8000    ; 0x8000-0x80FF 256 word color lookup table (0xXRGB)
-XVID_AUX_W_AUD           equ $C000    ; 0xC000-0x??? TODO (audio registers)
+; Xosera Main Registers (XM Registers, directly CPU accessable)
+; NOTE: Main register numbers are multiplied by 4 for rosco_m68k, because of even byte 6800 8-bit addressing plus
+; 16-bit registers
+XM_XR_ADDR      equ     $0          ; (R /W+) XR register number/address for XM_XR_DATA read/write access                         
+XM_XR_DATA      equ     $4          ; (R /W+) read/write XR register/memory at XM_XR_ADDR (XM_XR_ADDR incr. on write)           
+XM_RD_INCR      equ     $8          ; (R /W ) increment value for XM_RD_ADDR read from XM_DATA/XM_DATA_2                      
+XM_RD_ADDR      equ     $C          ; (R /W+) VRAM address for reading from VRAM when XM_DATA/XM_DATA_2 is read                 
+XM_WR_INCR      equ     $10         ; (R /W ) increment value for XM_WR_ADDR on write to XM_DATA/XM_DATA_2                    
+XM_WR_ADDR      equ     $14         ; (R /W ) VRAM address for writing to VRAM when XM_DATA/XM_DATA_2 is written                
+XM_DATA         equ     $18         ; (R+/W+) read/write VRAM word at XM_RD_ADDR/XM_WR_ADDR (and add XM_RD_INCR/XM_WR_INCR) 
+XM_DATA_2       equ     $1C         ; (R+/W+) 2nd XM_DATA(to allow for 32-bit read/write access)                                  
+XM_SYS_CTRL     equ     $20         ; (R /W+) busy status, FPGA reconfig, interrupt status/control, write masking                   
+XM_TIMER        equ     $24         ; (RO   ) read 1/10th millisecond timer [TODO]                                       
+XM_UNUSED_A     equ     $28         ; (R /W ) unused direct register 0xA [TODO]                                                     
+XM_UNUSED_B     equ     $2C         ; (R /W ) unused direct register 0xB [TODO]                                                     
+XM_RW_INCR      equ     $30         ; (R /W ) XM_RW_ADDR increment value on read/write of XM_RW_DATA/XM_RW_DATA_2             
+XM_RW_ADDR      equ     $34         ; (R /W+) read/write address for VRAM access from XM_RW_DATA/XM_RW_DATA_2                   
+XM_RW_DATA      equ     $38         ; (R+/W+) read/write VRAM word at XM_RW_ADDR (and add XM_RW_INCR)                           
+XM_RW_DATA_2    equ     $3C         ; (R+/W+) 2nd XM_RW_DATA(to allow for 32-bit read/write access)                               
 
+; XR Extended Register / Region (accessed via XM_XR_ADDR and XM_XR_DATA)
+
+; XR Register Regions
+XR_CONFIG_REGS  equ     $0000       ; $0000-$000F config XR registers
+XR_PA_REGS      equ     $0010       ; $0010-$0017 playfield A XR registers
+XR_PB_REGS      equ     $0018       ; $0018-$001F playfield B XR registers
+XR_BLIT_REGS    equ     $0020       ; $0020-$002F 2D-blit XR registers
+XR_DRAW_REGS    equ     $0030       ; $0030-$003F line/poly draw XR registers
+
+; XR Memory Regions
+XR_COLOR_MEM    equ     $8000       ; (WO) $8000-$80FF 256 x 16-bit color lookup memory ($xRGB)
+XR_TILE_MEM     equ     $9000       ; (WO) $9000-$9FFF 4096 x 16-bit tile glyph storage memory
+XR_COPPER_MEM   equ     $A000       ; (WO) $A000-$A7FF 2048 x 16-bit copper program memory
+XR_SPRITE_MEM   equ     $B000       ; (WO) $B000-$B0FF 256 x 16-bit sprite cursor memory
+XR_UNUSED_MEM   equ     $C000       ;      $C000-$FFFF unused
+
+; Video Config and Copper XR Registers
+XR_VID_CTRL     equ     $0000       ; (R /W) display control and border color index                                                 
+XR_COPP_CTRL    equ     $0001       ; (R /W) display synchronized coprocessor control                                               
+XR_CURSOR_X     equ     $0002       ; (R /W) sprite cursor X position                                                               
+XR_CURSOR_Y     equ     $0003       ; (R /W) sprite cursor Y position                                                               
+XR_VID_TOP      equ     $0004       ; (R /W) top line of active display window (typically 0)                                        
+XR_VID_BOTTOM   equ     $0005       ; (R /W) bottom line of active display window (typically 479)                                   
+XR_VID_LEFT     equ     $0006       ; (R /W) left edge of active display window (typically 0)                                       
+XR_VID_RIGHT    equ     $0007       ; (R /W) right edge of active display window (typically 639 or 847)                             
+XR_SCANLINE     equ     $0008       ; (RO  ) [15] in V blank, [14] in H blank [10:0] V scanline                                      
+XR_UNUSED_09    equ     $0009       ; (RO  )                                                                                         
+XR_VERSION      equ     $000A       ; (RO  ) Xosera optional feature bits [15:8] and version code [7:0] [TODO]                       
+XR_GITHASH_H    equ     $000B       ; (RO  ) [15:0] high 16-bits of 32-bit Git hash build identifier                                 
+XR_GITHASH_L    equ     $000C       ; (RO  ) [15:0] low 16-bits of 32-bit Git hash build identifier                                  
+XR_VID_HSIZE    equ     $000D       ; (RO  ) native pixel width of monitor mode (e.g. 640/848)                                       
+XR_VID_VSIZE    equ     $000E       ; (RO  ) native pixel height of monitor mode (e.g. 480)                                          
+XR_VID_VFREQ    equ     $000F       ; (RO  ) update frequency of monitor mode in BCD 1/100th Hz (0x5997 = 59.97 Hz) 
+
+; Playfield A Control XR Registers
+XR_PA_GFX_CTRL  equ     $0010       ; (R /W) playfield A graphics control
+XR_PA_TILE_CTRL equ     $0011       ; (R /W) playfield A tile control
+XR_PA_DISP_ADDR equ     $0012       ; (R /W) playfield A display VRAM start address
+XR_PA_LINE_LEN  equ     $0013       ; (R /W) playfield A display line width in words
+XR_PA_HV_SCROLL equ     $0014       ; (R /W) playfield A horizontal and vertical fine scroll
+XR_PA_LINE_ADDR equ     $0015       ; (R /W) playfield A scanline start address (loaded at start of line)
+XR_PA_UNUSED_16 equ     $0016       ;
+XR_PA_UNUSED_17 equ     $0017       ;
+
+; Playfield B Control XR Registers
+XR_PB_GFX_CTRL  equ     $0018       ; (R /W) playfield B graphics control
+XR_PB_TILE_CTRL equ     $0019       ; (R /W) playfield B tile control
+XR_PB_DISP_ADDR equ     $001A       ; (R /W) playfield B display VRAM start address
+XR_PB_LINE_LEN  equ     $001B       ; (R /W) playfield B display line width in words
+XR_PB_HV_SCROLL equ     $001C       ; (R /W) playfield B horizontal and vertical fine scroll
+XR_PB_LINE_ADDR equ     $001D       ; (R /W) playfield B scanline start address (loaded at start of line)
+XR_PB_UNUSED_1E equ     $001E       ;
+XR_PB_UNUSED_1F equ     $001F       ;
+
+; TODO blit and polydraw

--- a/code/firmware/rosco_m68k_development/videoXosera/xvidcon.asm
+++ b/code/firmware/rosco_m68k_development/videoXosera/xvidcon.asm
@@ -30,8 +30,8 @@ HAVE_XOSERA::
     move.l  A0,-(A7)
     jsr     INSTALL_TEMP_BERR_HANDLER
 
-    move.l  #XVID_BASE,A0
-    move.b  (XVID_DATA,A0),D0
+    move.l  #XM_BASEADDR,A0
+    move.b  (XM_DATA,A0),D0
 
     tst.b   BERR_FLAG
     bne.s   .NOXVID
@@ -51,7 +51,7 @@ HAVE_XOSERA::
 ; Initialize the console
 XOSERA_CON_INIT::
     movem.l D1-D3/A0-A1,-(A7)
-    move.l  #XVID_BASE,A0                     ; Use A0 as port base register
+    move.l  #XM_BASEADDR,A0                   ; Use A0 as port base register
 
     move.w  SR,D3                             ; Save SR
     ori.w   #$0200,SR                         ; No interrupts during init...
@@ -63,10 +63,8 @@ XOSERA_CON_INIT::
     tst.w   D0
     beq.s   .DONE 
 
-    move.w  #$B007,D0                         ; set special constant
-    movep.w D0,(XVID_CONST,A0)
-    move.w  #$8180,D0                         ; Reconfigure Xosera for config #1 (848x480)
-    movep.w D0,(XVID_BLIT_CTRL,A0)
+    move.w  #$A000,D0                         ; Reconfigure Xosera for config #1 (848x480)
+    movep.w D0,(XM_SYS_CTRL,A0)
 
     bsr.s   XVID_SYNC                         ; detect Xosera responding again
     ; if sync failed - fail the init
@@ -135,14 +133,14 @@ XVID_SYNC:
 
 .SYNC_LOOP
     move.w  #$55AA,D0
-    movep.w D0,(XVID_CONST,A0)                ; Do sync checks
-    movep.w (XVID_CONST,A0),D0                
+    movep.w D0,(XM_XR_ADDR,A0)                ; Do sync checks
+    movep.w (XM_XR_ADDR,A0),D0                
     cmp.w   #$55AA,D0
     bne.s   .SYNC_NEXT
 
     move.w  #$AA55,D0
-    movep.w D0,(XVID_CONST,A0)
-    movep.w (XVID_CONST,A0),D0                
+    movep.w D0,(XM_XR_ADDR,A0)
+    movep.w (XM_XR_ADDR,A0),D0                
     cmp.w   #$AA55,D0
     bne.s   .SYNC_NEXT
     rts                                       ; return D0 non-zero
@@ -261,7 +259,7 @@ BUFFERFLIP:
 
     ; Set up to write VRAM at 0x0
     clr.w   D1
-    movep.w D1,(XVID_WR_ADDR,A0)            ; Setup VRAM write
+    movep.w D1,(XM_WR_ADDR,A0)              ; Setup VRAM write
     
 .GOGOGO    
     move.w  DISPLAYSTART,D0
@@ -272,7 +270,7 @@ BUFFERFLIP:
     clr.w   D2
     move.b  (A1,D0),D2
     or.w    #$0A00,D2
-    movep.w D2,(XVID_DATA,A0)
+    movep.w D2,(XM_DATA,A0)
     addq.w  #1,D0
     cmpi.w  #DISPLAYSIZE,D0
     bne.s   .COPY
@@ -316,7 +314,7 @@ SETUP_VRAM_WRITE:
     addi.w  #DISPLAYSIZE,D3
 
 .WRITEVRAM
-    movep.w D3,(XVID_WR_ADDR,A0)       ; Setup VRAM write
+    movep.w D3,(XM_WR_ADDR,A0)       ; Setup VRAM write
     move.w  (A7)+,D3
     rts
 
@@ -345,7 +343,7 @@ XVID_CON_PUTCHAR::
 .NOTIGNORED
     movem.l D1-D3/A0-A1,-(A7)
     
-    move.l  #XVID_BASE,A0                 ; Use A0 as Xosera base
+    move.l  #XM_BASEADDR,A0                 ; Use A0 as Xosera base
     move.w  CURPOS,D1                     ; Load current pointer
  
     ; Is this a carriage-return?
@@ -386,7 +384,7 @@ XVID_CON_PUTCHAR::
     bsr.w   SETUP_VRAM_WRITE              ; Clear from VRAM
 
     move.w  #$0A20,D0
-    movep.w D0,(XVID_DATA,A0)             ; Overwrite character
+    movep.w D0,(XM_DATA,A0)             ; Overwrite character
 
     move.w  D3,SR                         ; Go ahead with the interrupts...
     move.b  #0,(A1,D1)                    ; Clear from buffer
@@ -408,7 +406,7 @@ XVID_CON_PUTCHAR::
 
     and.w   #$00FF,D0
     or.w    #$0A00,D0
-    movep.w D0,(XVID_DATA,A0)             ; And write,
+    movep.w D0,(XM_DATA,A0)             ; And write,
     move.w  D3,SR                         ; Go ahead with the interrupts...
     
     addq.w  #1,D1

--- a/code/software/bbsd/Makefile
+++ b/code/software/bbsd/Makefile
@@ -11,8 +11,7 @@ SYSLIBDIR?=../libs/build/lib
 DEFINES=-DROSCO_M68K -DFATFS_USE_CUSTOM_OPTS_FILE -DSPI_FASTER 					\
 		-DSPI_FAST -DSD_FASTER 
 CFLAGS=-std=c11 -ffreestanding -ffunction-sections -fdata-sections			\
-		-Wall -Werror -Wno-unused-function																	\
-		-Iinclude -Ifat_io_lib	-I$(SYSINCDIR)															\
+		-Wall -Werror -Wno-unused-function -I$(SYSINCDIR)										\
 		-msoft-float -mcpu=68010 -march=68010 -mtune=68010 $(DEFINES)
 GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 		| grep libraries:\ =																								\

--- a/code/software/bbsd/bbsd.c
+++ b/code/software/bbsd/bbsd.c
@@ -18,7 +18,7 @@
 
 #include "bbspi.h"
 #include "bbsd.h"
-#include "device/block.h"
+#include "include/device/block.h"
 
 static bool wait_for_card(BBSPI*, uint32_t);
 static void reset_card(BBSPI*);

--- a/code/software/bbsd/bbsd.h
+++ b/code/software/bbsd/bbsd.h
@@ -17,7 +17,7 @@
 #define ROSCO_M68K_BBSD_H
 
 #include <stdbool.h>
-#include <device/block.h>
+#include "include/device/block.h"
 
 #ifdef SD_MINIMAL
 #ifndef SD_BLOCK_READ_ONLY      // Minimal config precludes non-block-sized reads...

--- a/code/software/bbsd/kmain.c
+++ b/code/software/bbsd/kmain.c
@@ -22,9 +22,9 @@
 
 #include "bbspi.h"
 #include "bbsd.h"
-#include "device/block.h"
-#include "fat_access.h"
-#include "fat_filelib.h"
+#include "include/device/block.h"
+#include "fat_io_lib/fat_access.h"
+#include "fat_io_lib/fat_filelib.h"
 
 #define CS      GPIO1
 #define SCK     GPIO2
@@ -187,7 +187,7 @@ void kmain() {
   #ifndef SD_MINIMAL
   #ifdef _ROSCOM68K_STDIO_H
             uint32_t size = BBSD_get_size(&sd);
-            printf("with %d blocks (%d MB)\n", size, size / 2048);
+            printf("with %ld blocks (%ld MB)\n", size, size / 2048);
   #endif
   #else
             printf("(Size unknown in minimal configuration)\n");
@@ -203,7 +203,7 @@ void kmain() {
                 uint32_t open_time = timer_stop();
 
                 if (file != NULL) {
-                    printf("succeeded, time %d msec.\n", open_time);
+                    printf("succeeded, time %ld msec.\n", open_time);
                     printf("Reading \"ROSCODE1.BIN\"");
 
                     int c;
@@ -220,7 +220,7 @@ void kmain() {
                     uint32_t load_time = timer_stop();
 
                     uint32_t bytes = loadptr - loadstartptr;
-                    printf("\nFinished!  Bytes:%d (%0.02f KiB), Time:%0.03f sec., Speed:%0.02f KiB/sec.\n", bytes, bytes / 1024.0f, load_time / 1000.0f, (bytes / 1024.0f) / (load_time / 1000.0f));
+                    printf("\nFinished!  Bytes:%ld (%0.02f KiB), Time:%0.03f sec., Speed:%0.02f KiB/sec.\n", bytes, bytes / 1024.0f, load_time / 1000.0f, (bytes / 1024.0f) / (load_time / 1000.0f));
 #ifdef TEST_CYCLE
 
                     printf("Calculating CRC32...");

--- a/code/software/exception_tests/kmain.c
+++ b/code/software/exception_tests/kmain.c
@@ -77,14 +77,14 @@ void kmain() {
   INSTALL_HANDLER();
 
   // Generate a bus fault
-  printf("Bad is 0x%08x\r\n", *bad);
+  printf("Bad is 0x%08lx\r\n", *bad);
 
   if (berr_hit) {
     printf("\nBus Error occurred:\r\n");
-    printf("    Format was 0b%04b     (Indicating 680%d0 CPU)\r\n", fmt, cpuver);
+    printf("    Format was 0x%x       (Indicating 680%d0 CPU)\r\n", fmt, cpuver);
     printf("    VecOfs was 0x%06x   (Exception #%d)\r\n", vec_ofs, vec_ofs / 4);
     printf("    SR     was 0x%04x\r\n", sr);
-    printf("    PC     was 0x%08x\r\n", pc);
+    printf("    PC     was 0x%08lx\r\n", pc);
   } else {
     printf("Bus Error did not occur.\r\n");
   }

--- a/code/software/flashrom/kmain.c
+++ b/code/software/flashrom/kmain.c
@@ -95,7 +95,7 @@ void kmain() {
     printf("  Total size : %d bytes\n", CONFIG_SIZE);
     printf("  Base addr  : 0x%08x\n", CONFIG_ADDR);
 
-    printf("\nOld data: 0x%08x 0x%08x 0x%08x...\n", config->data[0], config->data[1], config->data[2]);
+    printf("\nOld data: 0x%08lx 0x%08lx 0x%08lx...\n", config->data[0], config->data[1], config->data[2]);
 
     uint32_t new_data;
     if (config->data[0] == 0x55AA55AA) {
@@ -111,7 +111,7 @@ void kmain() {
     if (!write_config_area(&new_config_buf)) {
         printf("Failed to write config area!\n");
     } else {
-        printf("New data: 0x%08x 0x%08x 0x%08x...\n", config->data[0], config->data[1], config->data[2]);
+        printf("New data: 0x%08lx 0x%08lx 0x%08lx...\n", config->data[0], config->data[1], config->data[2]);
     }
 }
 

--- a/code/software/libs/src/printf/include/printf.h
+++ b/code/software/libs/src/printf/include/printf.h
@@ -57,7 +57,7 @@ void _putchar(char character);
  * \return The number of characters that are written into the array, not counting the terminating null character
  */
 #define printf printf_
-int printf_(const char* format, ...);
+int printf_(const char* format, ...) __attribute__((format(__printf__, 1, 2)));
 
 
 /**
@@ -68,7 +68,7 @@ int printf_(const char* format, ...);
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
 #define sprintf sprintf_
-int sprintf_(char* buffer, const char* format, ...);
+int sprintf_(char* buffer, const char* format, ...) __attribute__((format(__printf__, 2, 3)));
 
 
 /**
@@ -83,7 +83,7 @@ int sprintf_(char* buffer, const char* format, ...);
  */
 #define snprintf  snprintf_
 #define vsnprintf vsnprintf_
-int  snprintf_(char* buffer, size_t count, const char* format, ...);
+int  snprintf_(char* buffer, size_t count, const char* format, ...) __attribute__((format(__printf__, 3, 4)));
 int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
 
 
@@ -105,7 +105,7 @@ int vprintf_(const char* format, va_list va);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are sent to the output function, not counting the terminating null character
  */
-int fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...);
+int fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...) __attribute__((format(__printf__, 3, 4)));
 
 
 #ifdef __cplusplus

--- a/code/software/libs/src/sdfat/fat_io_lib/fat_access.c
+++ b/code/software/libs/src/sdfat/fat_io_lib/fat_access.c
@@ -388,9 +388,9 @@ void fatfs_show_details(struct fatfs *fs)
 {
     FAT_PRINTF(("FAT details:\r\n"));
     FAT_PRINTF((" Type =%s", (fs->fat_type == FAT_TYPE_32) ? "FAT32": "FAT16"));
-    FAT_PRINTF((" Root Dir First Cluster = %x\r\n", fs->rootdir_first_cluster));
-    FAT_PRINTF((" FAT Begin LBA = 0x%x\r\n",fs->fat_begin_lba));
-    FAT_PRINTF((" Cluster Begin LBA = 0x%x\r\n",fs->cluster_begin_lba));
+    FAT_PRINTF((" Root Dir First Cluster = %lx\r\n", fs->rootdir_first_cluster));
+    FAT_PRINTF((" FAT Begin LBA = 0x%lx\r\n",fs->fat_begin_lba));
+    FAT_PRINTF((" Cluster Begin LBA = 0x%lx\r\n",fs->cluster_begin_lba));
     FAT_PRINTF((" Sectors Per Cluster = %d\r\n", fs->sectors_per_cluster));
 }
 //-----------------------------------------------------------------------------

--- a/code/software/libs/src/sdfat/fat_io_lib/fat_filelib.c
+++ b/code/software/libs/src/sdfat/fat_io_lib/fat_filelib.c
@@ -1494,7 +1494,7 @@ void fl_listdirectory(const char *path)
             }
             else
             {
-                FAT_PRINTF(("%s [%d bytes]\r\n", dirent.filename, dirent.size));
+                FAT_PRINTF(("%s [%ld bytes]\r\n", dirent.filename, dirent.size));
             }
         }
 

--- a/code/software/memcheck/kmain.c
+++ b/code/software/memcheck/kmain.c
@@ -81,7 +81,7 @@ static uint32_t count_rom_size() {
       }
 
       if (((uint32_t)current) % 4096 == 0) {
-        printf("\rROM: %dK %s", 
+        printf("\rROM: %ldK %s", 
             ((uint32_t)current) / 1024, "[\033[1;32m✔\033[0m]");
       }
 
@@ -177,7 +177,7 @@ static KRESULT build_memory_map(MEMINFO *header) {
     current++;
 
     if (current_addr % 65536 == 0) {
-      printf("\rRAM: %dK %s", 
+      printf("\rRAM: %ldK %s", 
           current_addr / 1024, 
           block_started ? "[\033[1;32m✔\033[0m]" : "[\033[1;31m✗\033[0m]");
     }
@@ -259,14 +259,14 @@ static void print_block(uint8_t i, MEMBLOCK *block) {
   
   if (block->block_size >= 65536) {
   
-    printf("%02d: 0x%08x - 0x%08x (%5d KiB  ) ", 
+    printf("%02d: 0x%08lx - 0x%08lx (%5ld KiB  ) ", 
         i, 
         block->block_start, 
         block->block_start + block->block_size - 1, 
         block->block_size / 1024);
   } else {
   
-    printf("%02d: 0x%08x - 0x%08x (%5d bytes) ", 
+    printf("%02d: 0x%08lx - 0x%08lx (%5ld bytes) ", 
         i, 
         block->block_start, 
         block->block_start + block->block_size - 1, 
@@ -322,7 +322,7 @@ static void show_banner() {
   }
   printf("        *\n");
   if (wver >= 0x0120) {
-    printf("* Firmware reports %8d bytes total contiguous memory *\n", *FW_MEMSIZE);
+    printf("* Firmware reports %8ld bytes total contiguous memory *\n", *FW_MEMSIZE);
   }
   printf("*                                                         *\n");
   printf("***********************************************************\n");
@@ -350,7 +350,7 @@ void kmain() {
   KRESULT result = build_memory_map(header);
 
   if (IS_KFAILURE(result)) {
-    printf("Failed to build memory map (0x%04x)\n", result);
+    printf("Failed to build memory map (0x%04lx)\n", result);
   } else {
     printf("Map built successfully\n");
 
@@ -363,7 +363,7 @@ void kmain() {
 
     RESTORE_BERR_HANDLER();
 
-    printf("Complete; Found a total of %d bytes of writeable RAM\n\n", header->ram_total);
+    printf("Complete; Found a total of %ld bytes of writeable RAM\n\n", header->ram_total);
   }
 }
 

--- a/code/software/updateflash/kmain.c
+++ b/code/software/updateflash/kmain.c
@@ -131,8 +131,8 @@ void kmain() {
     if (logical_romsize == 0) {
         printf("Apologies, but ROMs don't appear to be SST flash, this utility cannot program them.\n");
     } else {
-        printf("\nLogical ROM size is %d bytes\n", logical_romsize);
-        printf("%d bytes available for update file buffer\n\n", buffer_size);
+        printf("\nLogical ROM size is %ld bytes\n", logical_romsize);
+        printf("%ld bytes available for update file buffer\n\n", buffer_size);
 
         if (!SD_check_support()) {
             printf("Sorry, SD Card support is required in ROM, but is not present. Cannot read firmware update files.\n");
@@ -155,11 +155,11 @@ void kmain() {
                         printf("Apologies, but update is too large for logical ROM, cannot flash\n");
                     } else if (upgrade_romsize > buffer_size) {
                         printf("Sorry, update ROM cannot fit in available memory, and I cannot stream it yet. Cannot continue.\n");
-                        printf("(FYI, max update size with current memory configuration is %d bytes\n)", buffer_size);
+                        printf("(FYI, max update size with current memory configuration is %ld bytes\n)", buffer_size);
                     } else if ((upgrade_romsize & 1) == 1) {
                         printf("Sorry, but upgrade file size is odd, assuming invalid image. Cannot continue.\n");
                     } else {
-                        printf("Found an update ROM of %d bytes, Will attempt to flash :)\n", upgrade_romsize);
+                        printf("Found an update ROM of %ld bytes, Will attempt to flash :)\n", upgrade_romsize);
                         printf("Reading file...");
 
                         if (fl_fread(buffer, 1, upgrade_romsize, romfile) != (int)upgrade_romsize) {

--- a/code/software/warmboot/kmain.c
+++ b/code/software/warmboot/kmain.c
@@ -16,33 +16,33 @@ void kmain()
   mcDelaymsec10(250);
   printf("Example/test of rosco_m68k warm reboot.\n\n");
 
-  printf("rosco_m68k config (firmware: 0x%08X)\n", _FIRMWARE_REV);
+  printf("rosco_m68k config (firmware: 0x%08lX)\n", _FIRMWARE_REV);
   printf("------------------------------------\n");
-  printf(" Total memory     : 0x%08x (%d KiB)\n", _SDB_MEM_SIZE, _SDB_MEM_SIZE / 1024);
-  printf(" Available memory : 0x%08x (%d KiB)\n", _INITIAL_STACK, _INITIAL_STACK / 1024);
+  printf(" Total memory     : 0x%08lx (%ld KiB)\n", _SDB_MEM_SIZE, _SDB_MEM_SIZE / 1024);
+  printf(" Available memory : 0x%08lx (%ld KiB)\n", _INITIAL_STACK, _INITIAL_STACK / 1024);
   int32_t reserved = _SDB_MEM_SIZE - _INITIAL_STACK;
   if (reserved > 0)
   {
-    printf("  (0x%08x bytes reserved)\n", reserved);
+    printf("  (0x%08lx bytes reserved)\n", reserved);
   }
   else if (reserved < 0)
   {
     printf("  (ERROR: initial stack > memory size?)\n");
   }
-  printf(" ROM reset vector : 0x%08x\n", *rom_reset_vector);
-  printf(" Warm-boot vector : 0x%08x\n", _WARM_BOOT);
+  printf(" ROM reset vector : 0x%08lx\n", *rom_reset_vector);
+  printf(" Warm-boot vector : 0x%08lx\n", (uint32_t)_WARM_BOOT);
   printf("\n");
 
-  printf(" EFP_PRINT        : 0x%08x\n", _EFP_PRINT);
-  printf(" EFP_PRINTLN      : 0x%08x\n", _EFP_PRINTLN);
-  printf(" EFP_PRINTCHAR    : 0x%08x\n", _EFP_PRINTCHAR);
-  printf(" EFP_HALT         : 0x%08x\n", _EFP_HALT);
-  printf(" EFP_SENDCHAR     : 0x%08x\n", _EFP_SENDCHAR);
-  printf(" EFP_RECVCHAR     : 0x%08x\n", _EFP_RECVCHAR);
-  printf(" EFP_CLRSCR       : 0x%08x\n", _EFP_CLRSCR);
-  printf(" EFP_MOVEXY       : 0x%08x\n", _EFP_MOVEXY);
-  printf(" EFP_SETCURSOR    : 0x%08x\n", _EFP_SETCURSOR);
-  printf(" EFP_PROGLOADER   : 0x%08x\n", _EFP_PROGLOADER);
+  printf(" EFP_PRINT        : 0x%08lx\n", (uint32_t)_EFP_PRINT);
+  printf(" EFP_PRINTLN      : 0x%08lx\n", (uint32_t)_EFP_PRINTLN);
+  printf(" EFP_PRINTCHAR    : 0x%08lx\n", (uint32_t)_EFP_PRINTCHAR);
+  printf(" EFP_HALT         : 0x%08lx\n", (uint32_t)_EFP_HALT);
+  printf(" EFP_SENDCHAR     : 0x%08lx\n", (uint32_t)_EFP_SENDCHAR);
+  printf(" EFP_RECVCHAR     : 0x%08lx\n", (uint32_t)_EFP_RECVCHAR);
+  printf(" EFP_CLRSCR       : 0x%08lx\n", (uint32_t)_EFP_CLRSCR);
+  printf(" EFP_MOVEXY       : 0x%08lx\n", (uint32_t)_EFP_MOVEXY);
+  printf(" EFP_SETCURSOR    : 0x%08lx\n", (uint32_t)_EFP_SETCURSOR);
+  printf(" EFP_PROGLOADER   : 0x%08lx\n", (uint32_t)_EFP_PROGLOADER);
   printf("\n");
 
   if (reserved <= 0 || *(uint32_t *)_INITIAL_STACK != RESIDENT_MAGIC)
@@ -56,12 +56,12 @@ void kmain()
     __asm__ __volatile__ ("move.l %%a7,%[a7_after]\n" : [a7_after] "=d" (a7_after) : : );
     int32_t reserved = a7_before - a7_after;
     printf(" ... Completed.\n");
-    printf(" Test reserved 0x%08x bytes memory.\n", reserved);
+    printf(" Test reserved 0x%08lx bytes memory.\n", reserved);
   }
   else
   {
     printf("*** Resident signature detected, test already installed.\n");
-    printf(" ... Test signature @ 0x%08x = 0x%08x\n", _INITIAL_STACK, *(uint32_t *)_INITIAL_STACK);
+    printf(" ... Test signature @ 0x%08lx = 0x%08lx\n", _INITIAL_STACK, *(uint32_t *)_INITIAL_STACK);
   }
 
   printf("\nResident test loader completed.\n\n");


### PR DESCRIPTION
This adds GCC attributes to the header with printf and related functions to cause them to type check arguments and issue a warning on type mismatches.  This can be a bit a picky, but usually can be made happy with small tweak to format (and that is worth it for finding major mixu-ps).  This PR also fixes any new warnings in rosco_m68k software.