### PR TITLE
Support C++ (and C with GCC extension) global ctors/dtors

### DIFF
--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -68,7 +68,7 @@ PREMAIN:
     bsr.s   CALL_CTORS            ; Call global constructors
     lea.l   kmain,A0
     jsr     (A0)                  ; Fly user program, Fly!
-    move.l  #0,-(A7)              ; Call __cxa_atexit with NULL dso_handle
+    move.l  #0,-(A7)              ; Call __cxa_finalize with NULL dso_handle
     lea.l   __cxa_finalize,A0
     jsr     (A0)
     add.l   #4,A7

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -3,10 +3,10 @@
 ;  ___ ___ ___ ___ ___       _____|  _| . | |_
 ; |  _| . |_ -|  _| . |     |     | . | . | '_|
 ; |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
-;                     |_____|    firmware v1.2
+;                     |_____|           stdlibs
 ;------------------------------------------------------------
-; Copyright (c)2020 Ross Bamford See top-level LICENSE.md for licence
-; information.
+; Copyright (c)2020-2021 Ross Bamford See top-level LICENSE.md 
+; for licence information.
 ;
 ; This is the initialization code. The loader jumps into this code after the
 ; "program" is received via serial.
@@ -21,6 +21,9 @@
 ;
 ; All of this is depending on a bit of linker magic - see rosco_m68k_kernel.ld
 ; to see how that works.
+;
+; GCC global constructors/destructors (with attributes and 
+; __cxa_atexit) are supported here, too.
 ;------------------------------------------------------------
     include "../../shared/rosco_m68k_public.asm"
 
@@ -60,9 +63,57 @@ POSTINIT:                         ; running from copied run addr location
     dbra    D1,.COPY_LOOP         ; outer loop
 
 PREMAIN:
-    move.l  $0004,-(A7)           ; push (soft) reset vector if kmain returns
     lea.l   __kinit,A0
     jsr     (A0)                  ; prepare C environment
+    bsr.s   CALL_CTORS            ; Call global constructors
     lea.l   kmain,A0
-    jmp     (A0)                  ; Fly user program, Fly!
+    jsr     (A0)                  ; Fly user program, Fly!
+    move.l  #0,-(A7)              ; Call __cxa_atexit with NULL dso_handle
+    lea.l   __cxa_finalize,A0
+    jsr     (A0)
+    add.l   #4,A7
+    bsr.s   CALL_DTORS            ; Call global destructors
+    move.l  $0004,A0              ; And jump to soft reset
+    jmp     (A0) 
 
+CALL_CTORS::
+    movem.l A2-A4,-(A7)
+
+    move.l  #_ctors,A2
+    move.l  #_ctors_end,A3
+
+.LOOP
+    sub.l   #4,A3
+
+    cmp.l   A2,A3
+    bcs.s   .DONE
+
+    move.l  (A3),A4
+    jsr     (A4)
+
+    bra.s   .LOOP
+
+.DONE
+    movem.l (A7)+,A2-A4
+    rts
+
+
+CALL_DTORS::
+    movem.l A2-A4,-(A7)
+
+    move.l  #_dtors,A2
+    move.l  #_dtors_end,A3
+
+.LOOP
+    cmp.l   A3,A2
+    beq.s   .DONE
+
+    move.l  (A2),A4
+    jsr     (A4)
+
+    add.l   #4,A2
+    bra.s   .LOOP
+
+.DONE
+    movem.l (A7)+,A2-A4
+    rts

--- a/code/software/libs/src/start_serial/kinit.c
+++ b/code/software/libs/src/start_serial/kinit.c
@@ -4,22 +4,72 @@
  *  ___ ___ ___ ___ ___       _____|  _| . | |_ 
  * |  _| . |_ -|  _| . |     |     | . | . | '_|
  * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
- *                     |_____|       firmware v1                 
+ *                     |_____|           stdlibs 
  * ------------------------------------------------------------
- * Copyright (c)2020 Ross Bamford
+ * Copyright (c)2020-2021 Ross Bamford
  * See top-level LICENSE.md for licence information.
  *
- * Pre-main initialization for POC kernel.
+ * Pre-main initialization and cxa_atexit for rosco_m68k.
  * ------------------------------------------------------------
  */
 
+#include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
+
+// I don't really know how many of these is enough... This will take up 16KB.
+#define MAX_CXA_ATEXITS 1024
+
+typedef void (*cxa_atexit_func)(void *);
+
+typedef struct {
+    cxa_atexit_func func;
+    void            *ptr;
+    void            *dso_handle;
+    bool            done;
+} cxa_atexit_entry;    
 
 // Linker defines
 extern uint32_t _data_start, _data_end, _code_end, _bss_start, _bss_end;
 
+static cxa_atexit_entry cxa_atexits[MAX_CXA_ATEXITS];
+static uint16_t cxa_atexit_count;
+
+void *__dso_handle;
+
 void __kinit() {
   // zero .bss
   for (uint32_t *dst = &_bss_start; dst < &_bss_end; *dst++ = 0);
+}
+
+int __cxa_atexit ( void (*f)(void *), void *p, void *d ) {
+    if (cxa_atexit_count == MAX_CXA_ATEXITS) {
+        return 1; // failure!
+    } else {
+        cxa_atexit_entry *entry = &cxa_atexits[cxa_atexit_count++];
+
+        entry->func = f;
+        entry->ptr = p;
+        entry->dso_handle = d;
+        entry->done = false;
+
+        return 0;
+    }
+}
+
+/*
+ * We probably don't need the full dso_handle capability as we're always
+ * statically linked, but I'd rather do a proper impl now than have it 
+ * break later because of a half-baked one :D
+ */
+void __cxa_finalize(void *dso_handle) {
+    for (int i = cxa_atexit_count - 1; i >= 0; i--) {
+        cxa_atexit_entry *entry = &cxa_atexits[i];
+
+        if ((dso_handle == NULL || dso_handle == entry->dso_handle) && !entry->done) {
+            entry->func(entry->ptr);
+            entry->done = true;
+        }
+    }
 }
 

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -113,6 +113,22 @@ SECTIONS
     _code_end = .;
   } > RAM
 
+  .ctors ALIGN(4) : 
+  {
+      _ctors = .;
+      KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
+      KEEP(*(SORT(.ctors.*)))   /* followed by ctors with priority */
+      _ctors_end = .;
+  } > RAM
+
+  .dtors ALIGN(4) : 
+  {
+      _dtors = .;
+      KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first */
+      KEEP(*(.dtors))           /* Followed by non-priority ones */
+      _dtors_end = .;
+  } > RAM
+
   .data ALIGN(4) :
   {
     _data_start = .;

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -112,6 +112,22 @@ SECTIONS
     *(.rodata*)
     _code_end = .;
   } > RAM
+  
+  .ctors ALIGN(4) : 
+  {
+      _ctors = .;
+      KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
+      KEEP(*(SORT(.ctors.*)))   /* followed by ctors with priority */
+      _ctors_end = .;
+  } > RAM
+
+  .dtors ALIGN(4) : 
+  {
+      _dtors = .;
+      KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first, highest to lowest */
+      KEEP(*(.dtors))           /* Followed by non-priority ones */
+      _dtors_end = .;
+  } > RAM
 
   .data ALIGN(4) :
   {

--- a/code/software/tests/README.md
+++ b/code/software/tests/README.md
@@ -1,0 +1,8 @@
+# Tests
+
+This directory contains various tests of the different 
+functionality provided by the standard software environment.
+
+These are mostly quite low-level and shouldn't be taken as
+examples - they are here to prove that things work as they should.
+

--- a/code/software/tests/cpptest/Makefile
+++ b/code/software/tests/cpptest/Makefile
@@ -15,7 +15,7 @@ FLAGS=-ffreestanding -ffunction-sections -fdata-sections \
 				-Wall -Wextra -Werror -Wno-unused-function -pedantic -I$(SYSINCDIR) \
 				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU) $(DEFINES)
 CFLAGS=-std=c11 $(FLAGS)
-CXXFLAGX=-std=c++20 $(FLAGS)
+CXXFLAGS=-std=c++20 -fno-exceptions -fno-rtti $(FLAGS)
 GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 		| grep libraries:\ =																								\
     | sed 's/libraries: =/-L/g' 																				\

--- a/code/software/tests/cpptest/Makefile
+++ b/code/software/tests/cpptest/Makefile
@@ -3,10 +3,7 @@
 # Copyright (c) 2020 Xark
 # MIT LICENSE
 
-ifndef ROSCO_M68K_DIR
-$(error Please set ROSCO_M68K_DIR to the top-level rosco_m68k directory to use for rosco_m68k building)
-endif
-
+ROSCO_M68K_DIR?=../../../..
 -include $(ROSCO_M68K_DIR)/user.mk
 
 CPU?=68010

--- a/code/software/tests/cpptest/README.md
+++ b/code/software/tests/cpptest/README.md
@@ -1,0 +1,38 @@
+# C++ and Global Ctor/Dtor test
+
+Testing C++ and GCC attribute (global) constructor / destructor
+support in the `start_serial` library.
+
+## Building
+
+```
+make clean all
+```
+
+This will build `cpptest.bin`, which can be uploaded to a board that
+is running the standard firmware.
+
+If building for a HUGEROM machine (r2.x, or r1.x with adapter) you
+should build with:
+
+```
+ROSCO_M68K_HUGEROM=true make clean all
+```
+
+If you're feeling adventurous (and have ckermit installed), you
+can try:
+
+```
+SERIAL=/dev/some-serial-device make load
+```
+
+which will attempt to send the binary directly to your board (which
+must obviously be connected and waiting for the upload).
+
+This sample uses UTF-8. It's recommended to run minicom with colour
+and UTF-8 enabled, for example:
+
+```
+minicom -D /dev/your-device -c on -R utf-8
+```
+

--- a/code/software/tests/cpptest/acl.cpp
+++ b/code/software/tests/cpptest/acl.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 You (you@youremail.com)
+ */
+
+extern "C" void printIn(const char *op, const char* id);
+
+class AClass {
+    int i;
+
+    public:
+    AClass(const int i) {
+        printIn("Constructor", "AClass");
+        this->i = i;
+    }
+
+    ~AClass() {
+        printIn("Destructor", "AClass");
+    }
+
+    int num() {
+        return i;
+    }
+}; 
+
+AClass acl(42);
+
+extern "C" int getAclNum() {
+    return acl.num();
+}
+

--- a/code/software/tests/cpptest/bcl.cpp
+++ b/code/software/tests/cpptest/bcl.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020 You (you@youremail.com)
+ */
+
+extern "C" void printIn(const char *op, const char* id);
+
+class BClass {
+    int i;
+
+    public:
+    BClass(const int i) {
+        printIn("Constructor", "BClass");
+        this->i = i;
+    }
+
+    ~BClass() {
+        printIn("Destructor", "BClass");
+    }
+
+    int num() {
+        return i;
+    }
+}; 
+
+BClass bcl(64);
+
+extern "C" int getBclNum() {
+    return bcl.num();
+}
+

--- a/code/software/tests/cpptest/kmain.c
+++ b/code/software/tests/cpptest/kmain.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020 You (you@youremail.com)
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+extern void* _ctors;
+extern void* _ctors_end;
+extern void* _dtors;
+extern void* _dtors_end;
+extern int getAclNum();
+extern int getBclNum();
+
+__attribute__((constructor(101))) void gconstructor100() {
+    printf("Global constructor, priority 101 (via attribute, call via .ctors list; should run first)\n");
+}
+
+__attribute__((constructor(200))) void gconstructor200() {
+    printf("Global constructor, priority 200 (via attribute, call via .ctors list; should run second)\n");
+}
+
+__attribute__((constructor)) void gconstructorNP() {
+    printf("Global constructor, No priority (via attribute, call via .ctors list; should run after C++ ctors)\n");
+}
+
+__attribute__((destructor(200))) void gdestructor200() {
+    printf("Global destructor, priority 200 (via attribute, call via .dtors list, should run first [after C++ dtors])!\n");
+}
+
+__attribute__((destructor(101))) void gdestructor100() {
+    printf("Global destructor, priority 101 (via attribute, call via .dtors list, should run second)!\n");
+}
+
+__attribute__((destructor)) void gdestructor() {
+    printf("Global destructor, No priority (via attribute, call via .dtors list, should run last)!\n");
+}
+
+void printIn(const char *op, const char* id) {
+    printf("In C++ %s (registered with global ctor, dtor via __cxa_atexit): %s\n", op, id);
+}
+
+void kmain() {
+    printf("Now we're in main()\n");
+
+    printf("Constructors at 0x%08lx - 0x%08lx (%ld entries)\n", 
+            (uint32_t)&_ctors, (uint32_t)&_ctors_end, (((uint32_t)&_ctors_end) - ((uint32_t)&_ctors)) >> 2);
+    
+    printf("Destructors at 0x%08lx - 0x%08lx (%ld entries)\n",
+            (uint32_t)&_dtors, (uint32_t)&_dtors_end, (((uint32_t)&_dtors_end) - ((uint32_t)&_dtors)) >> 2);
+
+    printf("By now, global constructors have already been called, and C++ destructors are registered with __cxa_atexit...\n"); 
+    
+    printf("C++ constructor check for AClass: acl.num() returns %d (expect 42)\n", getAclNum());
+    printf("C++ constructor check for BClass: bcl.num() returns %d (expect 64)\n", getBclNum());
+
+    printf("Main will now exit, this should trigger C++ destructors followed by global ones...\n");
+}
+

--- a/code/starter_projects/starter_asm/Makefile
+++ b/code/starter_projects/starter_asm/Makefile
@@ -18,7 +18,7 @@ FLAGS=-ffreestanding -ffunction-sections -fdata-sections \
 				-Wall -Wextra -Werror -Wno-unused-function -pedantic -I$(SYSINCDIR) \
 				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU) $(DEFINES)
 CFLAGS=-std=c11 $(FLAGS)
-CXXFLAGX=-std=c++20 $(FLAGS)
+CXXFLAGS=-std=c++20 -fno-exceptions -fno-rtti $(FLAGS)
 GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 		| grep libraries:\ =																								\
     | sed 's/libraries: =/-L/g' 																				\

--- a/code/starter_projects/starter_asm/Makefile
+++ b/code/starter_projects/starter_asm/Makefile
@@ -14,9 +14,11 @@ EXTRA_CFLAGS?=-g -O1 -fomit-frame-pointer
 SYSINCDIR?=$(ROSCO_M68K_DIR)/code/software/libs/build/include
 SYSLIBDIR?=$(ROSCO_M68K_DIR)/code/software/libs/build/lib
 DEFINES=-DROSCO_M68K
-CFLAGS=-std=c11 -ffreestanding -ffunction-sections -fdata-sections \
+FLAGS=-ffreestanding -ffunction-sections -fdata-sections \
 				-Wall -Wextra -Werror -Wno-unused-function -pedantic -I$(SYSINCDIR) \
 				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU) $(DEFINES)
+CFLAGS=-std=c11 $(FLAGS)
+CXXFLAGX=-std=c++20 $(FLAGS)
 GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 		| grep libraries:\ =																								\
     | sed 's/libraries: =/-L/g' 																				\
@@ -33,6 +35,7 @@ endif
 LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 VASMFLAGS=-Felf -m68010 -quiet -Lnf $(DEFINES)
 CC=m68k-elf-gcc
+CXX=m68k-elf-g++
 AS=m68k-elf-as
 LD=m68k-elf-ld
 NM=m68k-elf-nm
@@ -58,9 +61,10 @@ SYM=$(PROGRAM_BASENAME).sym
 
 # Assume source files in Makefile directory are source files for project
 CSOURCES=$(wildcard *.c)
+CXXSOURCES=$(wildcard *.cpp)
 SSOURCES=$(wildcard *.S)
 ASMSOURCES=$(wildcard *.asm)
-SOURCES=$(CSOURCES) $(SSOURCES) $(ASMSOURCES)
+SOURCES=$(CSOURCES) $(CXXSOURCES) $(SSOURCES) $(ASMSOURCES)
 
 # Assume each source files makes an object file
 OBJECTS=$(addsuffix .o,$(basename $(SOURCES)))
@@ -83,6 +87,9 @@ $(OBJECTS): Makefile
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $<
+
+%.o : %.cpp
+	$(CXX) -c $(CXXFLAGS) $(EXTRA_CXXFLAGS) -o $@ $<
 
 %.o : %.asm
 	$(VASM) $(VASMFLAGS) $(EXTRA_VASMFLAGS) -L $(basename $@).lst -o $@ $<

--- a/code/starter_projects/starter_c/Makefile
+++ b/code/starter_projects/starter_c/Makefile
@@ -18,7 +18,7 @@ FLAGS=-ffreestanding -ffunction-sections -fdata-sections \
 				-Wall -Wextra -Werror -Wno-unused-function -pedantic -I$(SYSINCDIR) \
 				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU) $(DEFINES)
 CFLAGS=-std=c11 $(FLAGS)
-CXXFLAGX=-std=c++20 $(FLAGS)
+CXXFLAGS=-std=c++20 -fno-exceptions -fno-rtti $(FLAGS)
 GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 		| grep libraries:\ =																								\
     | sed 's/libraries: =/-L/g' 																				\


### PR DESCRIPTION
This PR adds the most basic support for C++ user code (basically, removing the global constructor/destructor footgun by supporting the basics of the Itanium CXX ABI as used by GCC-m68k: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#dso-dtor-runtime-api).

It also adds basic support for `__cxa_atexit` which G++ uses to register C++ destructors. This is not (currently) exposed to user code, but could quite easily be used to support user-code `atexit` handlers if desired.

There is a new test (in `code/software/tests/cpptest`) that tests the new functionality. Specifically, it exercises:

* C++ global constructors / destructors
* GCC `__attribute__((constructor))` and `__attribute__((destructor))` functions
  * With and without explicit priority

I have also run tests locally that check this doesn't break any existing code (that does not make use of these features) and am satisfied it doesn't.

Proof of life / Works On My Machine™:

<img width="920" alt="Screenshot 2021-11-11 at 20 58 13" src="https://user-images.githubusercontent.com/2096421/141368140-b3386ba3-92d7-499e-aa39-6a447cf911d4.png">

