### PR TITLE
Add uberlib

### DIFF
--- a/code/software/libs/Makefile
+++ b/code/software/libs/Makefile
@@ -26,6 +26,8 @@ INSTALL_DIR=./build
 INSTALL_LIB=$(INSTALL_DIR)/lib
 INSTALL_INC=$(INSTALL_DIR)/include
 
+UBERLIB=librosco_m68k.a
+
 # Avoid plain "make" building only the first target encountered, causing confusion
 decoy:
 	@echo Please use \"make all\" to build all the libraries.
@@ -53,18 +55,23 @@ include src/printf/include.mk
 
 .PHONY: all install clean clobber
 
-all: $(LIBS)
+all: $(UBERLIB) $(LIBS)
 
-install: $(LIBS)
+$(UBERLIB): $(filter-out **/printf-*.o, $(OBJECTS))
+	$(AR)	$(ARFLAGS) rs $@ $^
+	$(RANLIB) $@
+
+install: $(UBERLIB) $(LIBS)
 	$(MKDIR_P) $(INSTALL_INC)
 	$(MKDIR_P) $(INSTALL_LIB)
 	$(MKDIR_P) $(INSTALL_LIB)/ld/serial
 	$(CP_R) $(INCLUDES) $(INSTALL_INC)
 	$(CP_R) $(LIBS) $(INSTALL_LIB)
+	$(CP_R) $(UBERLIB) $(INSTALL_LIB)
 	$(CP_R) src/start_serial/link_scripts/* $(INSTALL_LIB)/ld/serial
 
 clean: 
-	$(RM_F) $(OBJECTS) $(LIBS)
+	$(RM_F) $(OBJECTS) $(LIBS) $(UBERLIB)
 
 clobber: clean
 	$(RM_RF)	$(INSTALL_DIR)

--- a/code/software/tests/uberlib-test/Makefile
+++ b/code/software/tests/uberlib-test/Makefile
@@ -3,10 +3,7 @@
 # Copyright (c) 2020 Xark
 # MIT LICENSE
 
-ifndef ROSCO_M68K_DIR
-$(error Please set ROSCO_M68K_DIR to the top-level rosco_m68k directory to use for rosco_m68k building)
-endif
-
+ROSCO_M68K_DIR=../../../..
 -include $(ROSCO_M68K_DIR)/user.mk
 
 CPU?=68010

--- a/code/software/tests/uberlib-test/kmain.c
+++ b/code/software/tests/uberlib-test/kmain.c
@@ -1,0 +1,10 @@
+/*
+ * Extremely simple test of uberlib linkage
+ */
+
+#include <stdio.h>
+
+void kmain() {
+  printf("Hello, world! Here is a float: %f\r\n", 3.1417);
+}
+

--- a/code/starter_projects/starter_c/Makefile
+++ b/code/starter_projects/starter_c/Makefile
@@ -21,7 +21,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 		| grep libraries:\ =																								\
     | sed 's/libraries: =/-L/g' 																				\
     | sed 's/:/m68000\/ -L/g')m68000/
-LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
+LIBS=-lrosco_m68k -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
 
 ifeq ($(ROSCO_M68K_HUGEROM),true)


### PR DESCRIPTION
This PR adds a single static library archive containing all rosco_m68k libraries in one dependency.

The intention is to simplify user code build by allowing just `-lrosco_m68k` to be linked rather than requiring the individual libs to be supplied in the correct (and increasingly-complex) order.

Thanks to @XarkLabs 's work to implement `--gc-sections` properly in the libs, this will have a negligible effect on user code (as unused stuff will simply be dropped by the linker). It **will** have  small effect on some things though, as `printf-softfloat` is the default - I think with the baseline configuration now having 115.2kbps and SD card, this is an acceptable increase. Of course is size is a major concern the individual libs are still available and can be linked as before.

(It's worth noting that, depending on what is used from the standard libs, `-lgcc` is likely to still be required - this is expected).