### PR TITLE
Remove the need to include <heap.h> in C++ code to use new/delete

### DIFF
--- a/code/software/libs/Makefile
+++ b/code/software/libs/Makefile
@@ -5,14 +5,18 @@
 
 CPU?=68010
 EXTRA_CFLAGS?=-g -O2
+EXTRA_CXXFLAGS?=-g -O2
 DEFINES:=$(DEFINES) -DROSCO_M68K_SYSLIBS
-CFLAGS=-std=c11 -ffreestanding -ffunction-sections -fdata-sections \
-				-nostartfiles -Wall -pedantic -Werror              \
-				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU)           \
+FLAGS=-ffreestanding -ffunction-sections -fdata-sections	\
+				-nostartfiles -Wall -pedantic -Werror       \
+				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU)    \
 				$(DEFINES)
+CFLAGS=-std=c11 $(FLAGS)
+CXXFLAGS=-std=c++20 -fno-exceptions -fno-rtti $(FLAGS)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 ARFLAGS=
 CC=m68k-elf-gcc
+CXX=m68k-elf-g++
 LD=m68k-elf-ld
 AR=m68k-elf-ar
 RANLIB=m68k-elf-ranlib
@@ -47,6 +51,9 @@ include src/printf/include.mk
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $<
+
+%.o : %.cpp
+	$(CXX) -c $(CXXFLAGS) $(EXTRA_CXXFLAGS) -o $@ $<
 
 %.o : %.S
 	$(AS) $(ASFLAGS) -o $@ $<

--- a/code/software/libs/Makefile
+++ b/code/software/libs/Makefile
@@ -8,9 +8,9 @@ EXTRA_CFLAGS?=-g -O2
 EXTRA_CXXFLAGS?=-g -O2
 DEFINES:=$(DEFINES) -DROSCO_M68K_SYSLIBS
 FLAGS=-ffreestanding -ffunction-sections -fdata-sections	\
-				-nostartfiles -Wall -pedantic -Werror       \
-				-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU)    \
-				$(DEFINES)
+			-nostartfiles -Wall -pedantic -Werror       				\
+			-mcpu=$(CPU) -march=$(CPU) -mtune=$(CPU)    				\
+			$(DEFINES)
 CFLAGS=-std=c11 $(FLAGS)
 CXXFLAGS=-std=c++20 -fno-exceptions -fno-rtti $(FLAGS)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)

--- a/code/software/libs/src/shmall/include.mk
+++ b/code/software/libs/src/shmall/include.mk
@@ -7,6 +7,7 @@ DIR := $(shell dirname $(lastword $(MAKEFILE_LIST)))
 UPPERLIB := $(shell echo $(LIB) | tr '[:lower:]' '[:upper:]')
 BINARY := lib$(LIB).a
 CFLAGS  := $(CFLAGS) -I$(LIBINCLUDES) -DBUILD_ROSCOM68K_$(UPPERLIB)_LIB
+CXXFLAGS := $(CXXFLAGS) -I$(LIBINCLUDES) -DBUILD_ROSCOM68K_$(UPPERLIB)_LIB
 OBJECTS := $(OBJECTS) $(LIBOBJECTS)
 INCLUDES := $(INCLUDES) $(DIR)/include/*
 LIBS := $(LIBS) $(DIR)/$(BINARY)

--- a/code/software/libs/src/shmall/include/heap.h
+++ b/code/software/libs/src/shmall/include/heap.h
@@ -25,10 +25,6 @@
 #ifndef __ROSCO_M68K_HEAP_H
 #define __ROSCO_M68K_HEAP_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stdint.h>
 #include <stddef.h>
 
@@ -84,18 +80,5 @@ void rh_switch_heap(heap_t *heap);
  * automatically).
  */
 void rh_default_heap();
-
-#ifdef __cplusplus
-}
-
-#include <cstdlib>
-
-inline void* operator new(size_t, void* p)      { return p; }
-inline void* operator new[](size_t, void* p)    { return p; }
-inline void* operator new(size_t size)          { return ::malloc(size); }
-
-inline void operator delete(void* p)            { ::free(p); }
-inline void operator delete(void* p, size_t)    { ::free(p); }
-#endif
 
 #endif//__ROSCO_M68K_HEAP_H

--- a/code/software/libs/src/shmall/rosco_m68k.cpp
+++ b/code/software/libs/src/shmall/rosco_m68k.cpp
@@ -13,7 +13,10 @@
  * ------------------------------------------------------------
  */
 
-#include <stdio.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include "heap.h"
 
@@ -52,7 +55,7 @@ void rh_default_heap() {
     current_heap = &__ROSCO_DEFAULT_HEAP;
 }
 
-void* malloc(uint32_t size) {
+void* malloc(size_t size) {
     return heap_alloc(current_heap, size);
 }
 
@@ -60,3 +63,18 @@ void free(void* ptr) {
     heap_free(current_heap, ptr);
 }
 
+#ifdef __cplusplus
+}
+
+// Argument types of std::size_t are replaced with size_t
+// Overloads that use std::align_val_t or std::nothrow_t are not included.
+
+void* operator new  (size_t count)  { return ::malloc(count); }
+void* operator new[](size_t count)  { return operator new  (count); }
+
+void operator delete  (void* ptr) noexcept          { ::free(ptr); }
+void operator delete[](void* ptr) noexcept          { operator delete  (ptr); }
+void operator delete  (void* ptr, size_t) noexcept  { operator delete  (ptr); }
+void operator delete[](void* ptr, size_t) noexcept  { operator delete[](ptr); }
+
+#endif

--- a/code/software/tests/malloc-test/bcl.cpp
+++ b/code/software/tests/malloc-test/bcl.cpp
@@ -2,8 +2,6 @@
  * Copyright (c) 2020 You (you@youremail.com)
  */
 
-#include <heap.h>
-
 int bclass_count = 0;
 
 class BClass {


### PR DESCRIPTION
This PR makes `rosco_m68k.c` in the `shmall` library into a C++ source file. Most of the content is contained in `extern "C"`, but implementations of `new` and `delete` are added.

All overloads which are defined as implicitly declared in every translation unit, even with the `<new>` header isn't included, are defined, except for those that use `std::align_val_t` or `std::nothrow_t` arguments. The `std::size_t` argument types are also replaced with `size_t`. The overloads call each other as specified for a standard library implementation.

The `malloc-test` test builds and runs cleanly, even after the `<heap.h>` header has been removed.