### PR TITLE
Fix easy68k comment (config is three bytes)

### DIFF
--- a/code/firmware/rosco_m68k_v2.0/easy68k/syscalls_asm.asm
+++ b/code/firmware/rosco_m68k_v2.0/easy68k/syscalls_asm.asm
@@ -10,8 +10,8 @@
 ;
 ; Easy68K-compatible system calls - assembly parts
 ;
-; Note that when compiled in this code reserves an SDB
-; DWORD for configuration at 0x410.
+; Note that when compiled in this code reserves three SDB
+; bytes for configuration at 0x410-0x412.
 ;------------------------------------------------------------
     include "../../../shared/rosco_m68k_public.asm"
     include "../rosco_m68k_private.asm"


### PR DESCRIPTION
The byte that was `E68K_RESERVED` is now `INTFLAGS`...