### PR TITLE
Fix `calloc` and `realloc`

### DIFF
--- a/code/software/libs/src/shmall/heap.c
+++ b/code/software/libs/src/shmall/heap.c
@@ -51,7 +51,7 @@ static void create_foot(node_t *head) {
 void init_heap(heap_t *heap, long start, long size) {
     node_t *init_region = (node_t *) start;
     init_region->hole = 1;
-    init_region->size = (HEAP_INIT_SIZE) - sizeof(node_t) - sizeof(footer_t);
+    init_region->size = size - sizeof(node_t) - sizeof(footer_t);
 
     create_foot(init_region);
 

--- a/code/software/libs/src/shmall/heap.c
+++ b/code/software/libs/src/shmall/heap.c
@@ -106,7 +106,7 @@ void heap_free(heap_t *heap, void *p) {
     bin_t *list;
     footer_t *new_foot, *old_foot;
 
-    node_t *head = (node_t *) ((char *) p - offset);
+    node_t *head = get_head(p);
     if (head == (node_t *) (uintptr_t) heap->start) {
         head->hole = 1; 
         add_node(heap->bins[get_bin_index(head->size)], head);
@@ -145,6 +145,10 @@ void heap_free(heap_t *heap, void *p) {
 
     head->hole = 1;
     add_node(heap->bins[get_bin_index(head->size)], head);
+}
+
+node_t *get_head(void *p) {
+    return (node_t *) ((char *) p - offset);
 }
 
 /* *** HACK (needed when using C++ and libgcc) *** */

--- a/code/software/libs/src/shmall/include/heap.h
+++ b/code/software/libs/src/shmall/include/heap.h
@@ -28,10 +28,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#define HEAP_INIT_SIZE 0x10000
-#define HEAP_MAX_SIZE 0xF0000
-#define HEAP_MIN_SIZE 0x10000
-
 #define MIN_ALLOC_SZ 4
 
 #define MIN_WILDERNESS 0x2000

--- a/code/software/libs/src/shmall/include/heap.h
+++ b/code/software/libs/src/shmall/include/heap.h
@@ -81,4 +81,9 @@ void rh_switch_heap(heap_t *heap);
  */
 void rh_default_heap();
 
+/*
+ * Get the header of a block
+ */
+node_t *get_head(void *p);
+
 #endif//__ROSCO_M68K_HEAP_H

--- a/code/software/libs/src/shmall/rosco_m68k.cpp
+++ b/code/software/libs/src/shmall/rosco_m68k.cpp
@@ -22,6 +22,17 @@ extern "C" {
 
 #define DEFAULT_STACK_SIZE  ((32 << 10)) // Default to 32KB stack
 
+// PLATFORM_THRESHOLD determines the minimum number of bytes needed to not use
+// the platform-independant naive implementation
+#if __m68k__
+#define PLATFORM_THRESHOLD 16
+// Data unit used by fast loop
+typedef uint16_t chunk_type;    // The type of each data unit, matches CHUNK_LETTER
+#define CHUNK_LETTER "w"        // The m68k instruction suffix, matches chunk_type
+#else
+#define PLATFORM_THRESHOLD 0
+#endif
+
 extern uint32_t _SDB_MEM_SIZE;
 extern uint32_t _end;
 
@@ -59,28 +70,131 @@ void* malloc(size_t size) {
     return heap_alloc(current_heap, size);
 }
 
-// TODO this could be significantly more efficient
+void free(void* ptr) {
+    if (ptr) {
+        heap_free(current_heap, ptr);
+    }
+}
+
+static void mem_clear(void *dst, size_t count) {
+    uint8_t *bdst = (uint8_t *) dst;
+    size_t count_left = count;
+
+    // Don't bother going fast with overhead for small sets
+    if (count_left < PLATFORM_THRESHOLD) {
+        goto platform_done;
+    }
+
+    // Handle the platform-specific case
+#if __m68k__
+    // Handle misaligned pointer bytes
+    while ((uintptr_t) bdst % alignof(chunk_type)) {
+        *(bdst++) = 0;
+        count_left -= 1;
+    }
+
+    // Loop over fast loop, fast loop limited to 16-bit counts
+    while (count_left >= sizeof(chunk_type)) {
+        // Calculate the number of fast loop iterations (minus one)
+        size_t chunks_left = count_left / sizeof(chunk_type);
+        uint16_t loop_counter = (uint16_t) (chunks_left - 1);
+        size_t chunks_to_loop = (size_t) loop_counter + 1;
+        count_left -= chunks_to_loop * sizeof(chunk_type);
+
+        // Fast loop, uses MC68010 loop mode
+        __asm__ volatile (
+            "1: clr" CHUNK_LETTER " %[bdst]@+\n\t"
+            "dbf %[loop_counter], 1b"
+            : [bdst] "+a" (bdst),
+              [loop_counter] "+d" (loop_counter)
+            :
+            : "cc", "memory"
+        );
+    }
+#endif
+
+platform_done:
+    // Handle any bytes left
+    for (; count_left > 0; --count_left) {
+        *(bdst++) = 0;
+    }
+}
+
+// Pointers must point to non-overlapping data
+static void mem_copy(void *dst, const void *src, size_t count) {
+    uint8_t *bdst = (uint8_t *) dst;
+    uint8_t *bsrc = (uint8_t *) src;
+    size_t count_left = count;
+
+    // Don't bother going fast with overhead for small sets
+    if (count_left < PLATFORM_THRESHOLD) {
+        goto platform_done;
+    }
+
+    // Handle the platform-specific case
+#if __m68k__
+    // If the destination and source have different chunk alignment offsets, then
+    // this code will be less efficient than the naive implementation, so skip to that
+    if ((uintptr_t) bdst % alignof(chunk_type) != (uintptr_t) bsrc % alignof(chunk_type)) {
+        goto platform_done;
+    }
+
+    // Handle misaligned pointer bytes
+    while ((uintptr_t) bdst % alignof(chunk_type) || (uintptr_t) bsrc % alignof(chunk_type)) {
+        *(bdst++) = *(bsrc++);
+        count_left -= 1;
+    }
+
+    // Loop over fast loop, fast loop limited to 16-bit counts
+    while (count_left >= sizeof(chunk_type)) {
+        // Calculate the number of fast loop iterations (minus one)
+        size_t chunks_left = count_left / sizeof(chunk_type);
+        uint16_t loop_counter = (uint16_t) (chunks_left - 1);
+        size_t chunks_to_loop = (size_t) loop_counter + 1;
+        count_left -= chunks_to_loop * sizeof(chunk_type);
+
+        // Fast loop, uses MC68010 loop mode
+        __asm__ volatile (
+            "1: move" CHUNK_LETTER " %[bsrc]@+, %[bdst]@+\n\t"
+            "dbf %[loop_counter], 1b"
+            : [bdst] "+a" (bdst),
+              [bsrc] "+a" (bsrc),
+              [loop_counter] "+d" (loop_counter)
+            :
+            : "cc", "memory"
+        );
+    }
+#endif
+
+platform_done:
+    // Handle any bytes left
+    for (; count_left > 0; --count_left) {
+        *(bdst++) = *(bsrc++);
+    }
+}
+
 void* calloc(size_t num, size_t size) {
     size_t total = num * size;
     void *mem = malloc(total);
 
-    if (mem != NULL) {
-        uint8_t *bmem = (uint8_t*)mem;
-        for (size_t i = 0; i < total; i++) {
-            bmem[i] = 0;
-        }
+    if (mem != NULL && total > 0) {
+        mem_clear(mem, total);
     }
 
     return mem;
 }
 
-// TODO this needs implementing!
 void* realloc(void *ptr, size_t new_size) {
-    return NULL;
-}
+    void *new_ptr = malloc(new_size);
 
-void free(void* ptr) {
-    heap_free(current_heap, ptr);
+    if (ptr != NULL && new_ptr != NULL && new_size > 0) {
+        // This will copy from past the end of ptr if the new size is greater than the old one
+        // TODO: This will break if we try to copy from non-existent memory
+        mem_copy(new_ptr, ptr, new_size);
+        free(ptr);
+    }
+
+    return new_ptr;
 }
 
 #ifdef __cplusplus

--- a/code/software/libs/src/shmall/rosco_m68k.cpp
+++ b/code/software/libs/src/shmall/rosco_m68k.cpp
@@ -27,8 +27,8 @@ extern "C" {
 #if __m68k__
 #define PLATFORM_THRESHOLD 16
 // Data unit used by fast loop
-typedef uint16_t chunk_type;    // The type of each data unit, matches CHUNK_LETTER
-#define CHUNK_LETTER "w"        // The m68k instruction suffix, matches chunk_type
+typedef uint32_t chunk_type;    // The type of each data unit, matches CHUNK_LETTER
+#define CHUNK_LETTER "l"        // The m68k instruction suffix, matches chunk_type
 #else
 #define PLATFORM_THRESHOLD 0
 #endif

--- a/code/software/tests/malloc-test/kmain.c
+++ b/code/software/tests/malloc-test/kmain.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <heap.h>
+#include <machine.h>
 
 static const char *test = "TESTING!TESTING!TESTING!TESTING!";
 
@@ -27,12 +28,128 @@ extern int newB();
 extern int getBNum();
 extern int deleteB();
 
+void calloc_check(size_t count, size_t size) {
+    size_t total = count * size;
+    bool success = true;
+
+    for (unsigned loop = 0; loop < 10 && success; ++loop) {
+        unsigned char *check_tmp = calloc(count, size);
+        if (!check_tmp) {
+            printf("calloc zero-check      : failed to calloc(0x%zX, 0x%zX)\n", count, size);
+            success = false;
+            break;
+        }
+
+        for (size_t i = 0; i < total; ++i) {
+            if (check_tmp[i] != 0) {
+                printf("calloc zero-check      : failed zero-check at loop %u byte 0x%zX\n", loop, i);
+                success = false;
+                break;
+            }
+            check_tmp[i] = i ^ loop;  // Fill with garbage
+        }
+        free(check_tmp);
+    }
+
+    if (success) {
+        printf("calloc zero-check      : succeeded\n");
+    }
+}
+
+void calloc_benchmark(size_t count, size_t size) {
+    printf("calloc benchmark       : starting\n");
+    bool success = true;
+    unsigned start_ticks = _TIMER_100HZ;
+
+    for (unsigned loop = 0; loop < 0x400; ++loop) {
+        void *ptr = calloc(count, size);
+        if (!ptr) {
+            printf("calloc benchmark       : failed to allocate\n");
+            success = false;
+            break;
+        }
+        free(ptr);
+    }
+
+    unsigned end_ticks = _TIMER_100HZ;
+    if (success) {
+        printf("calloc benchmark       : took %u ticks\n", end_ticks - start_ticks);
+    }
+}
+
+void realloc_check(size_t size) {
+    bool success = true;
+    void *current_ptr = NULL;
+
+    for (unsigned loop = 0; loop < 10 && success; ++loop) {
+        unsigned char *new_ptr = realloc(current_ptr, size);
+        if (!new_ptr) {
+            printf("realloc copy check     : failed to realloc(%p, 0x%zX)\n", current_ptr, size);
+            success = false;
+            break;
+        }
+
+        current_ptr = new_ptr;
+        for (size_t i = 0; i < size; ++i) {
+            if (loop > 0 && new_ptr[i] != (unsigned char) (i ^ (loop - 1))) {
+                printf("realloc copy check     : failed copy-check at loop %u byte 0x%zX\n", loop, i);
+                success = false;
+                break;
+            }
+            new_ptr[i] = i ^ loop;
+        }
+    }
+    free(current_ptr);
+
+    if (success) {
+        printf("realloc copy check     : succeeded\n");
+    }
+}
+
+void realloc_benchmark(size_t size) {
+    printf("realloc benchmark      : starting\n");
+    bool success = true;
+    void *current_ptr = NULL;
+    unsigned start_ticks = _TIMER_100HZ;
+
+    current_ptr = NULL;
+    for (unsigned loop = 0; loop < 0x400; ++loop) {
+        void *new_ptr = realloc(current_ptr, size);
+        if (!new_ptr) {
+            printf("realloc benchmark      : failed to allocate\n");
+            success = false;
+            break;
+        }
+        current_ptr = new_ptr;
+    }
+    free(current_ptr);
+
+    unsigned end_ticks = _TIMER_100HZ;
+    if (success) {
+        printf("realloc benchmark      : took %u ticks\n", end_ticks - start_ticks);
+    }
+}
+
 void kmain() {
     printf("C++ new/delete test starting\n");
     
     printf("new operator check     : newB returns    %d (expect 1)\n", newB());
     printf("new'd instance check   : getBNum returns %d (expect 9001)\n", getBNum());
     printf("delete operator check  : deleteB returns %d (expect 0)\n", deleteB());
+
+    // Check that freeing a NULL pointer doesn't fault
+    printf("free'ing NULL pointer  : ");
+    free(NULL);
+    printf("success\n");
+
+    size_t calloc_count = 0x1000;
+    size_t calloc_size = 0x8;
+    calloc_check(calloc_count, calloc_size);
+    calloc_benchmark(calloc_count, calloc_size);
+
+    size_t realloc_size = 0x4000;
+    realloc_check(realloc_size);
+    realloc_benchmark(realloc_size);
 
     printf("Malloc stress test starting, will run until interrupted...\n");
 

--- a/code/software/tests/malloc-test/kmain.c
+++ b/code/software/tests/malloc-test/kmain.c
@@ -29,20 +29,21 @@ extern int getBNum();
 extern int deleteB();
 
 void calloc_check(size_t count, size_t size) {
+    printf("calloc zero check      : starting\n");
     size_t total = count * size;
     bool success = true;
 
     for (unsigned loop = 0; loop < 10 && success; ++loop) {
         unsigned char *check_tmp = calloc(count, size);
         if (!check_tmp) {
-            printf("calloc zero-check      : failed to calloc(0x%zX, 0x%zX)\n", count, size);
+            printf("calloc zero check      : failed to calloc(0x%zX, 0x%zX)\n", count, size);
             success = false;
             break;
         }
 
         for (size_t i = 0; i < total; ++i) {
             if (check_tmp[i] != 0) {
-                printf("calloc zero-check      : failed zero-check at loop %u byte 0x%zX\n", loop, i);
+                printf("calloc zero check      : failed at loop %u byte 0x%zX\n", loop, i);
                 success = false;
                 break;
             }
@@ -52,7 +53,7 @@ void calloc_check(size_t count, size_t size) {
     }
 
     if (success) {
-        printf("calloc zero-check      : succeeded\n");
+        printf("calloc zero check      : succeeded\n");
     }
 }
 
@@ -61,10 +62,10 @@ void calloc_benchmark(size_t count, size_t size) {
     bool success = true;
     unsigned start_ticks = _TIMER_100HZ;
 
-    for (unsigned loop = 0; loop < 0x400; ++loop) {
+    for (unsigned loop = 0; loop < 0x80; ++loop) {
         void *ptr = calloc(count, size);
         if (!ptr) {
-            printf("calloc benchmark       : failed to allocate\n");
+            printf("calloc benchmark       : failed to calloc(0x%zX, 0x%zX)\n", count, size);
             success = false;
             break;
         }
@@ -78,6 +79,7 @@ void calloc_benchmark(size_t count, size_t size) {
 }
 
 void realloc_check(size_t size) {
+    printf("realloc copy check     : starting\n");
     bool success = true;
     void *current_ptr = NULL;
 
@@ -113,10 +115,10 @@ void realloc_benchmark(size_t size) {
     unsigned start_ticks = _TIMER_100HZ;
 
     current_ptr = NULL;
-    for (unsigned loop = 0; loop < 0x400; ++loop) {
+    for (unsigned loop = 0; loop < 0x80; ++loop) {
         void *new_ptr = realloc(current_ptr, size);
         if (!new_ptr) {
-            printf("realloc benchmark      : failed to allocate\n");
+            printf("realloc benchmark      : failed to realloc(%p, 0x%zX)\n", current_ptr, size);
             success = false;
             break;
         }
@@ -143,18 +145,16 @@ void kmain() {
     printf("success\n");
 
     size_t calloc_count = 0x1000;
-    size_t calloc_size = 0x8;
+    size_t calloc_size = 0x40;
     calloc_check(calloc_count, calloc_size);
     calloc_benchmark(calloc_count, calloc_size);
 
-    size_t realloc_size = 0x4000;
+    size_t realloc_size = 0x40000;
     realloc_check(realloc_size);
     realloc_benchmark(realloc_size);
 
     printf("Malloc stress test starting, will run until interrupted...\n");
-
     uint32_t allocs = 0;
-
     while (true) {
         char *str = malloc(33);
 


### PR DESCRIPTION
This implements `realloc`, and adds a platform-specific fast clear and fast copy for the `calloc` and `realloc`, respectively.

Also fixes the heap size being set to `HEAP_INIT_SIZE` instead of the actual space, and fixes faulting on freeing a `NULL` pointer.

I've added some benchmarks and tests to `malloc-test`. The benchmarks should print out a number of ticks, but I always end up with the difference being 0, it seems like the ticks stop (blinking stops) once the program is loaded. I'm not sure if there's some quirk somewhere or if I've got something setup wrong, but my benchmarks came from external timing instead.

I compare the non-platform-specific pure C default case to the case with `__m68k__` enabled (two data sizes) below:

| Benchmark | `calloc` | `realloc` |
| --- | --- | --- |
| Pure C | 84 s | 97 s |
| M68k fast word | 18 s | 25 s |
| M68k fast long | 13 s | 19 s |

Fixes #273.