### PR TITLE
Make FW1.3 buildable with GCC 11

### DIFF
--- a/code/firmware/rosco_m68k_v1.3/main1.c
+++ b/code/firmware/rosco_m68k_v1.3/main1.c
@@ -110,7 +110,7 @@ static void initialize_warm_reboot() {
 /* Main stage 1 entry point - Only called during cold boot */
 noreturn void main1() {
     if (sdb->magic != 0xB105D47A) {
-        FW_PRINT_C("\x1b[1;31mSEVERE\x1b[0m: SDB Magic mismatch; SDB is trashed. Stop.\r\n");
+        FW_PRINT_C("\x1b[1;31mSEVERE\x1b[0m: SDB Magic mismatch! Stop.\r\n");
         HALT();
     }
 


### PR DESCRIPTION
* Taking the easy road, just cutting down a (rarely-seen) error message to shave some bytes...
* Tested with latest GCC from home-brew tap