### PR TITLE
Feature/fix 285

### DIFF
--- a/code/software/2dmaze/Makefile
+++ b/code/software/2dmaze/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/adventure/Makefile
+++ b/code/software/adventure/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/dhrystone/Makefile
+++ b/code/software/dhrystone/Makefile
@@ -35,7 +35,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lheap -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(ARCH)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/dhrystone/bench.txt
+++ b/code/software/dhrystone/bench.txt
@@ -33,6 +33,7 @@ Last updated 20/11/2020 by roscopeco
  * rosco_m68k   68020-12Mhz     ROM             gcc-7.5.0        -      2604 (-O1)
  * rosco_m68k   68020-12Mhz     ROM             gcc-10.2.0       -      2860 (-O1)
  * rosco_m68k   68020-12Mhz     ROM             gcc-10.2.0       -      2941 (-O1 -mtune=68020)
+ * rosco_pro    68030-20Mhz     ROM             gcc-10.2.0       -      4545 (-O1 -mtune=68030)
  * Gould PN9080 custom ECL      UTX-32 1.1C     cc              4745    4992
  * VAX-784      -               Mach/4.3        cc              5263    5555 &4
  * VAX 8600     -               4.3 BSD         cc              6329    6423

--- a/code/software/dhrystone/bench.txt
+++ b/code/software/dhrystone/bench.txt
@@ -33,7 +33,6 @@ Last updated 20/11/2020 by roscopeco
  * rosco_m68k   68020-12Mhz     ROM             gcc-7.5.0        -      2604 (-O1)
  * rosco_m68k   68020-12Mhz     ROM             gcc-10.2.0       -      2860 (-O1)
  * rosco_m68k   68020-12Mhz     ROM             gcc-10.2.0       -      2941 (-O1 -mtune=68020)
- * rosco_pro    68030-20Mhz     ROM             gcc-10.2.0       -      4545 (-O1 -mtune=68030)
  * Gould PN9080 custom ECL      UTX-32 1.1C     cc              4745    4992
  * VAX-784      -               Mach/4.3        cc              5263    5555 &4
  * VAX 8600     -               4.3 BSD         cc              6329    6423

--- a/code/software/easy68k-demo/Makefile
+++ b/code/software/easy68k-demo/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/ehbasic/Makefile
+++ b/code/software/ehbasic/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/gpio-interrupt/Makefile
+++ b/code/software/gpio-interrupt/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/gpiodemo/Makefile
+++ b/code/software/gpiodemo/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/lcd-ili9341/Makefile
+++ b/code/software/lcd-ili9341/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/libm-test/Makefile
+++ b/code/software/libm-test/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/life/Makefile
+++ b/code/software/life/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/markm-ide/fat_format/Makefile
+++ b/code/software/markm-ide/fat_format/Makefile
@@ -20,7 +20,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -ldebug_stub -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/markm-ide/hdfat_menu/Makefile
+++ b/code/software/markm-ide/hdfat_menu/Makefile
@@ -21,7 +21,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -ldebug_stub -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/markm-ide/lowlevel/Makefile
+++ b/code/software/markm-ide/lowlevel/Makefile
@@ -23,7 +23,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -ldebug_stub -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/memcheck/Makefile
+++ b/code/software/memcheck/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/sdfat_demo/Makefile
+++ b/code/software/sdfat_demo/Makefile
@@ -18,7 +18,7 @@ CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
 			 -mcpu=68010 -march=68010 -mtune=68010 -Wno-unused-function				\
 			 -mno-align-int -mno-strict-align $(DEFINES)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/sdfat_menu/Makefile
+++ b/code/software/sdfat_menu/Makefile
@@ -31,7 +31,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(ARCH)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/sdfat_menu/sdfat_menu.c
+++ b/code/software/sdfat_menu/sdfat_menu.c
@@ -53,12 +53,12 @@ static unsigned int filecrc;                                           // curren
 // timer helpers
 unsigned int timer_start()
 {
-    //unsigned int t;
+    unsigned int t;
     unsigned int ts = _TIMER_100HZ;
     // synchronize start to next 100Hz interrupt
-//    while ((t = _TIMER_100HZ) == ts)
-//        ;
-    return ts;
+    while ((t = _TIMER_100HZ) == ts)
+        ;
+    return t;
 }
 
 unsigned int timer_stop(unsigned int start_tick)

--- a/code/software/sdfat_menu/sdfat_menu.c
+++ b/code/software/sdfat_menu/sdfat_menu.c
@@ -53,12 +53,12 @@ static unsigned int filecrc;                                           // curren
 // timer helpers
 unsigned int timer_start()
 {
-    unsigned int t;
+    //unsigned int t;
     unsigned int ts = _TIMER_100HZ;
     // synchronize start to next 100Hz interrupt
-    while ((t = _TIMER_100HZ) == ts)
-        ;
-    return t;
+//    while ((t = _TIMER_100HZ) == ts)
+//        ;
+    return ts;
 }
 
 unsigned int timer_stop(unsigned int start_tick)

--- a/code/software/tests/cpptest/Makefile
+++ b/code/software/tests/cpptest/Makefile
@@ -23,7 +23,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/tests/malloc-test/Makefile
+++ b/code/software/tests/malloc-test/Makefile
@@ -23,7 +23,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lheap -lsdfat -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/tests/uberlib-test/Makefile
+++ b/code/software/tests/uberlib-test/Makefile
@@ -21,7 +21,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lrosco_m68k -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/updateflash/Makefile
+++ b/code/software/updateflash/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/vterm/Makefile
+++ b/code/software/vterm/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lheap -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/software/warmboot/Makefile
+++ b/code/software/warmboot/Makefile
@@ -28,7 +28,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs \
 LIBS= $(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=68010 -march=68010
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/starter_projects/starter_asm/Makefile
+++ b/code/starter_projects/starter_asm/Makefile
@@ -26,7 +26,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lrosco_m68k -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld

--- a/code/starter_projects/starter_c/Makefile
+++ b/code/starter_projects/starter_c/Makefile
@@ -26,7 +26,7 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
 LIBS=-lrosco_m68k -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(CPU)
 
-ifeq ($(ROSCO_M68K_HUGEROM),true)
+ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld
 else
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/rosco_m68k_program.ld


### PR DESCRIPTION
Make HUGEROM build be the default for all example code in `develop` now that r2 is out. 
