### PR TITLE
Fix #269

### DIFF
--- a/code/firmware/rosco_m68k_v2.1/InterfaceReference.md
+++ b/code/firmware/rosco_m68k_v2.1/InterfaceReference.md
@@ -1372,7 +1372,7 @@ must be accessed through the public TRAP functions!
 | 0x438   | FW_CLRSCR - Clear the default console (where supported)                                           |
 | 0x43C   | FW_MOVEXY - Move cursor to (X,Y) (see note 1)                                                     |
 | 0x440   | FW_SETCURSOR - Show (D0.B > 0) or hide (D0.B == 0) the cursor                                     |
-| 0x444   | RESERVED                                                                                          |
+| 0x444   | FW_CHECKCHAR - Determine whether a character is available on the default UART                     |
 | 0x448   | FW_PROGRAM_LOADER - The firmware uses this to invoke the program loader (defaults to SD/Kermit)   |
 | 0x44C   | FW_SD_INIT - Initialize SD Card                                                                   |
 | 0x450   | FW_SD_READ - Read from SD Card                                                                    |
@@ -1390,7 +1390,8 @@ must be accessed through the public TRAP functions!
 | 0x480   | FW_ATA_INIT - Initialize ATA PIO device                                                           |
 | 0x484   | FW_ATA_READ - Read from ATA device                                                                |
 | 0x488   | FW_ATA_WRITE - Write to ATA device                                                                |
-| 0x48C   | FW_ATA_IDENT - `IDENTIFY` ATA device                                                               |
+| 0x48C   | FW_ATA_IDENT - `IDENTIFY` ATA device                                                              |
+| 0x490   | FW_PROG_EXIT - Vector used by library code to support the exit() function                         |
 
 **Note 1**: FW_GOTOXY takes the coordinates to move to from D1.W. The high
 byte is the X coordinate (Column) and the low byte is the Y coordinate (Row).

--- a/code/firmware/rosco_m68k_v2.1/bootstrap.asm
+++ b/code/firmware/rosco_m68k_v2.1/bootstrap.asm
@@ -243,6 +243,7 @@ INITSDB:
     move.l  #ANSI_MOVEXY,EFP_MOVEXY
     move.l  #ANSI_CLRSCR,EFP_CLRSCR
     move.l  #.RETURN,EFP_SETCURSOR     ; No-op for default SET CURSOR
+    move.l  #START,EFP_PROG_EXIT       ; Initial PROG_EXIT is reset vec
 
 .RETURN
     rts

--- a/code/firmware/rosco_m68k_v2.1/main1.c
+++ b/code/firmware/rosco_m68k_v2.1/main1.c
@@ -32,10 +32,11 @@
 extern void debug_stub();
 #endif
 
-#define INIT_STACK_VEC_ADDRESS 0x0
-#define RESET_VEC_ADDRESS 0x4
-#define PROGRAM_LOADER_EFP_ADDRESS 0x448
-#define MEM_SIZE_SDB_ADDRESS 0x414
+#define INIT_STACK_VEC_ADDRESS      0x0
+#define RESET_VEC_ADDRESS           0x4
+#define PROGRAM_LOADER_EFP_ADDRESS  0x448
+#define PROGRAM_EXIT_EFP_ADDRESS    0x490
+#define MEM_SIZE_SDB_ADDRESS        0x414
 
 extern void INSTALL_EASY68K_TRAP_HANDLERS();
 #ifdef BLOCKDEV_SUPPORT
@@ -61,6 +62,7 @@ static uint32_t* volatile program_loader_ptr = (uint32_t*)PROGRAM_LOADER_EFP_ADD
 static uint32_t* volatile reset_vector_ptr = (uint32_t*)RESET_VEC_ADDRESS;
 static uint32_t* volatile init_stack_vector_ptr = (uint32_t*)INIT_STACK_VEC_ADDRESS;
 static uint32_t* volatile mem_size_sdb_ptr = (uint32_t*)MEM_SIZE_SDB_ADDRESS;
+static uint32_t* volatile prog_exit_ptr = (uint32_t*)PROGRAM_EXIT_EFP_ADDRESS;
 
 // Stage 2 loads at 0x2000
 static Stage2 stage2 = (Stage2) 0x2000;
@@ -111,7 +113,7 @@ static void initialize_loader_efp() {
 
 static void initialize_warm_reboot() {
     *init_stack_vector_ptr = *mem_size_sdb_ptr;
-    *reset_vector_ptr = (uint32_t)warm_boot;
+    *prog_exit_ptr = *reset_vector_ptr = (uint32_t)warm_boot;
 }
 
 void print_cpu_mem_info() {

--- a/code/shared/rosco_m68k_public.asm
+++ b/code/shared/rosco_m68k_public.asm
@@ -73,6 +73,7 @@ EFP_ATA_INIT    equ     $480
 EFP_ATA_READ    equ     $484
 EFP_ATA_WRITE   equ     $488
 EFP_ATA_IDENT   equ     $48C
+EFP_PROG_EXIT   equ     $490
 
 ; MFP Location
 MFPBASE     equ     IOBASE

--- a/code/software/libs/src/cstdlib/stdlib.c
+++ b/code/software/libs/src/cstdlib/stdlib.c
@@ -7,18 +7,18 @@
 
 void exit(int status)
 {
-  // Warm-reboot machine when quit
+  // Jump to EFP_PROG_EXIT when quit
   __asm__ __volatile__ (
-      "moveal 0xfc0004.l, %a0\n\t"
+      "moveal 0x490.l, %a0\n\t"
       "jmp %a0@\n\t"
   );
 }
 
 void abort(void)
 {
-  // Warm-reboot machine when quit (should this blink LED or something)
+  // Jump to reset vector when abort
   __asm__ __volatile__ (
-      "moveal 0xfc0004.l, %a0\n\t"
+      "moveal 0x4.l, %a0\n\t"
       "jmp %a0@\n\t"
   );
 }

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -63,11 +63,23 @@ POSTINIT:                         ; running from copied run addr location
     dbra    D1,.COPY_LOOP         ; outer loop
 
 PREMAIN:
+    ; Save existing program exit EFP
+    ; Cannot use stack as we may jump directly with exit() or abort(),
+    ; from arbitrarily nested code...
+    move.l  EFP_PROG_EXIT,SAVE_PROG_EXIT
+
+    ; And set up new one at POSTMAIN
+    move.l  #.POSTMAIN,EFP_PROG_EXIT
+ 
     lea.l   __kinit,A0
     jsr     (A0)                  ; prepare C environment
     bsr.s   CALL_CTORS            ; Call global constructors
     lea.l   kmain,A0
     jsr     (A0)                  ; Fly user program, Fly!
+
+.POSTMAIN:
+    ; Restore EFP_PROG_EXIT
+    move.l  SAVE_PROG_EXIT,EFP_PROG_EXIT
     move.l  #0,-(A7)              ; Call __cxa_finalize with NULL dso_handle
     lea.l   __cxa_finalize,A0
     jsr     (A0)
@@ -117,3 +129,8 @@ CALL_DTORS::
 .DONE
     movem.l (A7)+,A2-A4
     rts
+
+    section .data
+
+SAVE_PROG_EXIT  ds.l  1
+

--- a/code/software/tests/cpptest/kmain.c
+++ b/code/software/tests/cpptest/kmain.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 extern void* _ctors;
 extern void* _ctors_end;
@@ -56,5 +57,8 @@ void kmain() {
     printf("C++ constructor check for BClass: bcl.num() returns %d (expect 64)\n", getBclNum());
 
     printf("Main will now exit, this should trigger C++ destructors followed by global ones...\n");
+    printf("Using explicit exit() call to test that destructors still get called...\n");
+    printf("(See https://github.com/rosco-m68k/rosco_m68k/issues/269)\n\n");
+    exit(99);
 }
 


### PR DESCRIPTION
Fix #269 by:

* Introducing new `EFP_PROG_EXIT` at `0x490`.
* Initially set new EFP to reset vector (and update when warm boot is setup)
* In `start_serial` lib `init.S`, save that EFP and swap it out for a label just after main.
* When we hit that label (either through jump to EFP or normal main return), restore saved EFP
* Update libs `exit` function to jump to EFP

This PR also fixes an hardcoded ROM address in `abort`, changing it to the reset vector in RAM.