### PR TITLE
Feature/fix firmware rev display in ansiterm

### DIFF
--- a/code/firmware/rosco_m68k_v2.1/videoXoseraANSI/xosera_ansiterm_m68k.c
+++ b/code/firmware/rosco_m68k_v2.1/videoXoseraANSI/xosera_ansiterm_m68k.c
@@ -1771,15 +1771,18 @@ static const char xansiterm_banner[] =
     "\x1b[35mX\x1b[93mo\x1b[33ms\x1b[96me\x1b[92mr\x1b[91ma \x1b[0mv";                     // 0.20
 static const char xansiterm_banner2[] = " XANSI \x1b[93m|_____|\x1b[0m  Classic ";         // 2.x\r\n;
 
-static char* str_hex(char *buf, unsigned int num) {
-    if (num > 0xf) {
+static char* str_hex(char *buf, unsigned int num) 
+{
+    if (num > 0xf) 
+    {
         buf = str_hex(buf, num >> 4);
     }
     *buf++ = "0123456789ABCDEF"[num & 0xf];
     return buf;
 }
 
-static char* str_fw_rev(char *buf, unsigned int ver) {
+static char* str_fw_rev(char *buf, unsigned int ver) 
+{
     buf = str_hex(buf, (ver & 0xf00) >> 8);
     *buf++ = '.';
     return str_hex(buf, ver & 0xff);

--- a/code/firmware/rosco_m68k_v2.1/videoXoseraANSI/xosera_ansiterm_m68k.c
+++ b/code/firmware/rosco_m68k_v2.1/videoXoseraANSI/xosera_ansiterm_m68k.c
@@ -1771,6 +1771,20 @@ static const char xansiterm_banner[] =
     "\x1b[35mX\x1b[93mo\x1b[33ms\x1b[96me\x1b[92mr\x1b[91ma \x1b[0mv";                     // 0.20
 static const char xansiterm_banner2[] = " XANSI \x1b[93m|_____|\x1b[0m  Classic ";         // 2.x\r\n;
 
+static char* str_hex(char *buf, unsigned int num) {
+    if (num > 0xf) {
+        buf = str_hex(buf, num >> 4);
+    }
+    *buf++ = "0123456789ABCDEF"[num & 0xf];
+    return buf;
+}
+
+static char* str_fw_rev(char *buf, unsigned int ver) {
+    buf = str_hex(buf, (ver & 0xf00) >> 8);
+    *buf++ = '.';
+    return str_hex(buf, ver & 0xff);
+}
+
 // initialize terminal functions
 // TODO: ICP default values
 bool xansiterm_INIT()
@@ -1811,6 +1825,7 @@ bool xansiterm_INIT()
     *vs++ = '\0';
     xansiterm_PRINT(verstr);
     xansiterm_PRINT(xansiterm_banner2);
+
     vs = verstr;
     if (!(_FIRMWARE_REV & (1U << 31)))
     {
@@ -1819,9 +1834,7 @@ bool xansiterm_INIT()
         *vs++ = ' ';
         *vs++ = ' ';
     }
-    str_dec(&vs, (_FIRMWARE_REV >> 8) & 0xf);
-    *vs++ = '.';
-    str_dec(&vs, (_FIRMWARE_REV >> 0) & 0xf);
+    vs = str_fw_rev(vs, _FIRMWARE_REV);
     if (_FIRMWARE_REV & (1U << 31))
     {
         *vs++ = '.';


### PR DESCRIPTION
Recent change in the way firmware encodes version broke Xosera ansiterm (my bad). This should fix it.

Proof of life:
![IMG_0225](https://user-images.githubusercontent.com/2096421/150531228-c6f00a81-adff-4bdf-b4dd-eb4c52940bba.JPG)

