### PR TITLE
Don't try to return from a bus error on a 68000

### DIFF
--- a/code/firmware/rosco_m68k_v2.1/bootstrap.asm
+++ b/code/firmware/rosco_m68k_v2.1/bootstrap.asm
@@ -493,7 +493,9 @@ BERR_HANDLER::
     beq.w   .IS020 
 
     ; If we're here, assume it's a 68000.
-    bra.s   .DONE
+    ; We can't return from a bus error, signal error.
+    move.l  (A7)+,D0
+    jmp     BUS_ERROR_HANDLER
 
 .IS020
     move.w  ($E,A7),D0                ; If we're here, it's an 020 frame...                


### PR DESCRIPTION
On Discord, aowron made me realize that the temporary bus error handler will try to `RTE` on a bus error when an MC68000 is used. This will fail because the stack layout is different than what the '000 `RTE` expects, and will probably try to jump to the address of the bus error.

Even though the MC68000 isn't really supported, it would be better to try to signal a bus error rather than to mysteriously crash (assuming that the frame isn't mistaken for that of another chip, but there's nothing we can do about that anyways).