### PR TITLE
Bandaid fix for `<string.h>` in C++

### DIFF
--- a/code/software/adventure/adventure.c
+++ b/code/software/adventure/adventure.c
@@ -34,6 +34,7 @@
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #ifdef __CC65__
 #include <conio.h>

--- a/code/software/libs/src/cstdlib/ctype.c
+++ b/code/software/libs/src/cstdlib/ctype.c
@@ -1,0 +1,68 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _   
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
+ *                     |_____|       firmware v1                 
+ * ------------------------------------------------------------
+ * Copyright (c)2022 Ross Bamford and contributors
+ * See top-level LICENSE.md for licence information.
+ *
+ * Basic implementations for ctype routines
+ * ------------------------------------------------------------
+ */
+
+#include <ctype.h>
+
+int isalnum(int c) {
+    return isalpha(c) || isdigit(c);
+}
+
+int isalpha(int c) {
+    return islower(c) || isupper(c);
+}
+
+int islower(int c) {
+    return c >= 'a' && c <= 'z';
+}
+
+int isupper(int c) {
+    return c >= 'A' && c <= 'Z';
+}
+
+int isdigit(int c) {
+    return c >= '0' && c <= '9';
+}
+
+int isxdigit(int c) {
+    return isdigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+int iscntrl(int c) {
+    return (c >= 0x00 && c <=0x1F) || c == 0x7F;
+}
+
+int isgraph(int c) {
+    return isalnum(c) || ispunct(c);
+}
+
+int isspace(int c) {
+    return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v';
+}
+
+int isblank(int c) {
+    return c == ' ' || c == '\t';
+}
+
+int isprint(int c) {
+    return isgraph(c) || c == '\t';
+}
+
+int tolower(int c) {
+    return isupper(c) ? (c) + ('a' - 'A') : c;
+}
+
+int toupper(int c) {
+    return islower(c) ? (c) + ('A' - 'a') : c;
+}

--- a/code/software/libs/src/cstdlib/ctype.c
+++ b/code/software/libs/src/cstdlib/ctype.c
@@ -56,7 +56,7 @@ int isblank(int c) {
 }
 
 int isprint(int c) {
-    return isgraph(c) || c == '\t';
+    return isgraph(c) || c == ' ';
 }
 
 int tolower(int c) {

--- a/code/software/libs/src/cstdlib/include.mk
+++ b/code/software/libs/src/cstdlib/include.mk
@@ -1,5 +1,5 @@
 LIB=cstdlib
-LIBOBJECTS=$(DIR)/ctype.o $(DIR)/string.o $(DIR)/fgets.o $(DIR)/stdlib.o
+LIBOBJECTS=$(DIR)/ctype.o $(DIR)/strings.o $(DIR)/string.o $(DIR)/fgets.o $(DIR)/stdlib.o
 LIBINCLUDES=$(DIR)/include
 
 # ---===---

--- a/code/software/libs/src/cstdlib/include.mk
+++ b/code/software/libs/src/cstdlib/include.mk
@@ -1,5 +1,5 @@
 LIB=cstdlib
-LIBOBJECTS=$(DIR)/string.o $(DIR)/fgets.o $(DIR)/stdlib.o
+LIBOBJECTS=$(DIR)/ctype.o $(DIR)/string.o $(DIR)/fgets.o $(DIR)/stdlib.o
 LIBINCLUDES=$(DIR)/include
 
 # ---===---

--- a/code/software/libs/src/cstdlib/include/ctype.h
+++ b/code/software/libs/src/cstdlib/include/ctype.h
@@ -6,7 +6,7 @@
  * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
  *                     |_____|       firmware v1                 
  * ------------------------------------------------------------
- * Copyright (c)2019 Ross Bamford
+ * Copyright (c)2022 Ross Bamford and contributors
  * See top-level LICENSE.md for licence information.
  *
  * Stub "ctype" for simple programs that need it
@@ -16,9 +16,21 @@
 #ifndef _ROSCOM68K_CTYPE_H
 #define _ROSCOM68K_CTYPE_H
 
-#include <stdint.h>
+int isalnum(int ch);
+int isalpha(int ch);
+int islower(int ch);
+int isupper(int ch);
+int isdigit(int ch);
+int isxdigit(int ch);
+int iscntrl(int ch);
+int isgraph(int ch);
+int isspace(int ch);
+int isblank(int ch);
+int isprint(int ch);
+int ispunct(int ch);
 
-typedef unsigned long size_t;
+int tolower(int ch);
+int toupper(int ch);
 
 #endif
 

--- a/code/software/libs/src/cstdlib/include/ctype.h
+++ b/code/software/libs/src/cstdlib/include/ctype.h
@@ -6,7 +6,7 @@
  * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
  *                     |_____|       firmware v1                 
  * ------------------------------------------------------------
- * Copyright (c)2022 Ross Bamford and contributors
+ * Copyright (c)2019-2022 Ross Bamford and contributors
  * See top-level LICENSE.md for licence information.
  *
  * Stub "ctype" for simple programs that need it

--- a/code/software/libs/src/cstdlib/include/string.h
+++ b/code/software/libs/src/cstdlib/include/string.h
@@ -6,7 +6,7 @@
  * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
  *                     |_____|       firmware v1                 
  * ------------------------------------------------------------
- * Copyright (c)2019 Ross Bamford
+ * Copyright (c)2019-2022 Ross Bamford and contributors
  * See top-level LICENSE.md for licence information.
  *
  * Simple, incomplete "string.h" for simple programs that need it
@@ -18,32 +18,18 @@
 
 #include <stddef.h>
 
-void* memset(void *str, int c, size_t n);
-void *memcpy(const void *to, const void *from, size_t n);
-char* memchr(register const char* src_void, int c, size_t length);
-size_t strlen(const char *s);
-int strcmp(const char *str1, const char *str2);
-int strcasecmp (const char *s1, const char *s2);
-int strncasecmp (const char *s1, const char *s2, size_t n);
+void *memchr(const void *s, int c, size_t n);
+void *memcpy(void *__restrict s1, const void *__restrict s2, size_t n);
+void *memset(void *s, int c, size_t n);
+char *strcat(char *__restrict s1, const char *__restrict s2);
 char *strchr(const char *s, int c);
+int strcmp(const char *s1, const char *s2);
+char *strcpy(char *__restrict s1, const char *__restrict s2);
+size_t strlen(const char *s);
+char *strncat(char *__restrict s1, const char *__restrict s2, size_t n);
+int strncmp(const char *s1, const char *s2, size_t n);
+char *strncpy(char *__restrict s1, const char *__restrict s2, size_t n);
+size_t strnlen(const char *s, size_t maxlen);
 char *strrchr(const char *s, int c);
-int islower(int c);
-int isupper(int c);
-int tolower(int c);
-int toupper(int c);
-size_t strnlen(const char* str, size_t maxlen);
-int strncmp(const char* s1, const char* s2, size_t n);
-char *strncpy(char *to, const char *from, size_t n);
-char *strcpy(char *to, const char *from);
-char *
-strncat (char *__restrict s1,
-	const char *__restrict s2,
-	size_t n);
-
-char *
-strcat (char *__restrict s1,
-	const char *__restrict s2);
-
 
 #endif
-

--- a/code/software/libs/src/cstdlib/include/strings.h
+++ b/code/software/libs/src/cstdlib/include/strings.h
@@ -1,0 +1,24 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _   
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
+ *                     |_____|       firmware v1                 
+ * ------------------------------------------------------------
+ * Copyright (c)2019-2022 Ross Bamford and contributors
+ * See top-level LICENSE.md for licence information.
+ *
+ * Simple, incomplete "strings.h" for simple programs that need it
+ * ------------------------------------------------------------
+ */
+
+#ifndef _ROSCOM68K_STRINGS_H
+#define _ROSCOM68K_STRINGS_H
+
+#include <stddef.h>
+
+int strcasecmp(const char *s1, const char *s2);
+int strncasecmp(const char *s1, const char *s2, size_t n);
+
+#endif

--- a/code/software/libs/src/cstdlib/string.c
+++ b/code/software/libs/src/cstdlib/string.c
@@ -6,7 +6,7 @@
  * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
  *                     |_____|       firmware v1                 
  * ------------------------------------------------------------
- * Copyright (c)2019 Ross Bamford
+ * Copyright (c)2019-2022 Ross Bamford and contributors
  * See top-level LICENSE.md for licence information.
  *
  * Basic implementations for string routines, until we get 

--- a/code/software/libs/src/cstdlib/string.c
+++ b/code/software/libs/src/cstdlib/string.c
@@ -14,34 +14,14 @@
  * ------------------------------------------------------------
  */
 
+#include <string.h>
 #include <stdint.h>
 #include <stddef.h>
 
-void* memset(void *str, int c, size_t n) {
-    // totally naive implementation, will do for now...
-    uint8_t *buf = (uint8_t*) str;
+void *memchr(const void *s, int c, size_t n) {
+  const unsigned char *src = (const unsigned char *)s;
 
-    for (uint8_t *end = buf + n; buf < end; *buf++ = c)
-        ;
-
-    return str;
-}
-
-void* memcpy(const void *to, const void *from, size_t n) {
-    // totally naive implementation, will do for now...
-    uint8_t *fbuf = (uint8_t*) from;
-    uint8_t *tbuf = (uint8_t*) to;
-
-    for (uint8_t *end = fbuf + n; fbuf < end; *tbuf++ = *fbuf++)
-        ;
-
-    return tbuf;
-}
-
-char* memchr(register const char* src_void, int c, size_t length) {
-  const unsigned char *src = (const unsigned char *)src_void;
-
-  while (length-- > 0) {
+  while (n-- > 0) {
       if (*src == c) {
           return (char*)src;
       }
@@ -50,112 +30,71 @@ char* memchr(register const char* src_void, int c, size_t length) {
   return NULL;
 }
 
-size_t strlen(const char *s) {
-    size_t i;
-    for (i = 0; s[i] != '\0'; i++) ;
-    return i;
+void *memcpy(void *__restrict s1, const void *__restrict s2, size_t n) {
+    // totally naive implementation, will do for now...
+    uint8_t *fbuf = (uint8_t*) s2;
+    uint8_t *tbuf = (uint8_t*) s1;
+
+    for (uint8_t *end = fbuf + n; fbuf < end; *tbuf++ = *fbuf++)
+        ;
+
+    return tbuf;
 }
 
-int strcmp(const char *str1, const char *str2) {
+void *memset(void *s, int c, size_t n) {
+    // totally naive implementation, will do for now...
+    uint8_t *buf = (uint8_t*) s;
+
+    for (uint8_t *end = buf + n; buf < end; *buf++ = c)
+        ;
+
+    return s;
+}
+
+char *strchr(const char *s, int c) {
+    while (*s != (char)c) {
+        if (!*s++) {
+            return NULL;
+        }
+    }
+    return (char *)s;
+}
+
+int strcmp(const char *s1, const char *s2) {
     // totally naive implementation, will do for now...
     register char c1, c2;
 
-    while ((c1 = *str1++)) {
-        if (!(c2 = *str2++)) {
+    while ((c1 = *s1++)) {
+        if (!(c2 = *s2++)) {
             return 1;
         } else if (c1 != c2) {
             return c1 - c2;
         }
     }
 
-    if (*str2) {
+    if (*s2) {
         return -1;
     } else {
         return 0;
     }
 }
 
-int isupper(int c) {
-  return (c >= 'A' && c <= 'Z');
+char *strcpy(char *__restrict s1, const char *__restrict s2) {
+	register char *d = s1;
+
+    while ((*d++ = *s2++) != 0)
+		;
+
+	return s1;
 }
 
-int islower(int c) {
-  return (c >= 'a' && c <= 'z');
+size_t strlen(const char *s) {
+    size_t i;
+    for (i = 0; s[i] != '\0'; i++) ;
+    return i;
 }
 
-int toupper(int c) {
-  return islower(c) ? (c) - ('a' - 'A') : c;
-}
-
-int tolower(int c) {
-  return isupper(c) ? (c) + ('a' - 'A') : c;
-}
-
-int strcasecmp (const char *s1, const char *s2) {
-    const unsigned char *p1 = (const unsigned char *) s1;
-    const unsigned char *p2 = (const unsigned char *) s2;
-    int result;
-
-    if (p1 == p2) {
-        return 0;
-    }
-
-    while ((result = tolower (*p1) - tolower (*p2++)) == 0) {
-        if (*p1++ == '\0') {
-            break;
-        }
-    }
-
-    return result;
-}
-
-int strncasecmp (const char *s1, const char *s2, size_t n) {
-    const unsigned char *p1 = (const unsigned char *) s1;
-    const unsigned char *p2 = (const unsigned char *) s2;
-    int result = 0;
-
-    if (p1 == p2) {
-        return 0;
-    }
-
-    while (n-- && (result = tolower (*p1) - tolower (*p2++)) == 0) {
-        if (*p1++ == '\0') {
-            break;
-        }
-    }
-
-    return result;
-}
-
-char *strchr(const char *s, int c) {
-    while (*s != (char)c) {
-        if (!*s++) {
-            return 0;
-        }
-    }
-    return (char *)s;
-}
-
-char *strrchr(const char *s, int c) {
-    const char* ret=0;
-    do {
-        if( *s == (char)c ) {
-            ret=s;
-        }
-    } while(*s++);
-    return (char*)ret;
-}
-
-size_t strnlen(const char* str, size_t maxlen) {
-    char*  p = memchr(str, 0, maxlen);
-    if (p == NULL) {
-        return maxlen;
-    } else {
-        return (p - str);
-    }
-}
-
-int strncmp(const char* s1, const char* s2, size_t n) {
+int strncmp(const char *s1, const char *s2, size_t n) {
     const unsigned char *p1 = (const unsigned char *) s1;
     const unsigned char *p2 = (const unsigned char *) s2;
     int result = 0;
@@ -172,22 +111,32 @@ int strncmp(const char* s1, const char* s2, size_t n) {
     return result;
 }
 
-char* strncpy(char *to, const char *from, size_t n) {
-  size_t size = strnlen (from, n);
+char *strncpy(char *__restrict s1, const char *__restrict s2, size_t n) {
+  size_t size = strnlen (s2, n);
   if (size != n) {
-    memset (to + size, '\0', n - size);
+    memset (s1 + size, '\0', n - size);
   }
 
-  return memcpy (to, from, size);
+  return memcpy (s1, s2, size);
 }
 
-char *strcpy(char *to, const char *from) {
-	register char *d = to;
+size_t strnlen(const char *s, size_t maxlen) {
+    char *p = memchr(s, 0, maxlen);
+    if (p == NULL) {
+        return maxlen;
+    } else {
+        return (p - s);
+    }
+}
 
-    while ((*d++ = *from++) != 0)
-		;
-
-	return to;
+char *strrchr(const char *s, int c) {
+    const char* ret = NULL;
+    do {
+        if(*s == (char)c) {
+            ret = s;
+        }
+    } while(*s++);
+    return (char*)ret;
 }
 
 /*
@@ -199,7 +148,7 @@ INDEX
 
 SYNOPSIS
 	#include <string.h>
-	char *strncat(char *restrict <[dst]>, const char *restrict <[src]>,
+	char *strncat(char *__restrict <[dst]>, const char *__restrict <[src]>,
                       size_t <[length]>);
 
 DESCRIPTION

--- a/code/software/libs/src/cstdlib/strings.c
+++ b/code/software/libs/src/cstdlib/strings.c
@@ -1,0 +1,56 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _   
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_ 
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
+ *                     |_____|       firmware v1                 
+ * ------------------------------------------------------------
+ * Copyright (c)2019 Ross Bamford
+ * See top-level LICENSE.md for licence information.
+ *
+ * Basic implementations for string routines, until we get 
+ * a libc sorted...
+ * ------------------------------------------------------------
+ */
+
+#include <strings.h>
+#include <ctype.h>
+#include <stddef.h>
+#include <string.h>
+
+int strcasecmp(const char *s1, const char *s2) {
+    const unsigned char *p1 = (const unsigned char *) s1;
+    const unsigned char *p2 = (const unsigned char *) s2;
+    int result;
+
+    if (p1 == p2) {
+        return 0;
+    }
+
+    while ((result = tolower(*p1) - tolower(*p2++)) == 0) {
+        if (*p1++ == '\0') {
+            break;
+        }
+    }
+
+    return result;
+}
+
+int strncasecmp(const char *s1, const char *s2, size_t n) {
+    const unsigned char *p1 = (const unsigned char *) s1;
+    const unsigned char *p2 = (const unsigned char *) s2;
+    int result = 0;
+
+    if (p1 == p2) {
+        return 0;
+    }
+
+    while (n-- && (result = tolower(*p1) - tolower(*p2++)) == 0) {
+        if (*p1++ == '\0') {
+            break;
+        }
+    }
+
+    return result;
+}

--- a/code/software/libs/src/cstdlib/strings.c
+++ b/code/software/libs/src/cstdlib/strings.c
@@ -6,7 +6,7 @@
  * |_| |___|___|___|___|_____|_|_|_|___|___|_,_| 
  *                     |_____|       firmware v1                 
  * ------------------------------------------------------------
- * Copyright (c)2019 Ross Bamford
+ * Copyright (c)2019-2022 Ross Bamford and contributors
  * See top-level LICENSE.md for licence information.
  *
  * Basic implementations for string routines, until we get 

--- a/code/software/markm-ide/hdfat_menu/kmain.c
+++ b/code/software/markm-ide/hdfat_menu/kmain.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <stdnoreturn.h>
 #include <string.h>
+#include <strings.h>
 
 #include <basicio.h>
 #include <debug_stub.h>

--- a/code/software/sdfat_menu/sdfat_menu.c
+++ b/code/software/sdfat_menu/sdfat_menu.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <stdnoreturn.h>
 #include <string.h>
+#include <strings.h>
 
 #include <basicio.h>
 #include <machine.h>


### PR DESCRIPTION
This fixes #308, where the use of the `register` keyword caused `<string.h>` to not be usable in C++. There were also some functions in it that had the wrong types.

While I was at it, I split out the content that was in `<string.h>` that should be in `<ctype.h>` or `<strings.h>`.

This is really only a stopgap, the non-freestanding part of the stdlib is still missing bits, most of the `<c...>` C++-style headers aren't in, and there's missing `extern "C"`, but it should fix this specific issue for now.