### PR TITLE
Fix alignment fault in start_serial init.S

### DIFF
--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -131,6 +131,7 @@ CALL_DTORS::
     rts
 
     section .data
+    align  4
 
 SAVE_PROG_EXIT  ds.l  1
 


### PR DESCRIPTION
An odd number of bytes in `.data` before linking start_serial caused a fault due to SAVE_PROG_EXIT being misaligned.
This adds an alignment directive.

Reported by mifritscher#8143 in Discord.