### PR TITLE
Fix #320

### DIFF
--- a/code/firmware/rosco_m68k_firmware/rev1.asm
+++ b/code/firmware/rosco_m68k_firmware/rev1.asm
@@ -62,8 +62,7 @@ TICK_HANDLER::
     move.w  D0,SDB_TICKCNT            ; ... and write back to SDB
     move.l  (A7)+,D1                  ; Restore D1
 
-    move.b  R_STOPCNTCMD(A0),D0       ; Clear ISR[3]
-    move.l  (A7)+,A0                  ; Restore A0
+    move.b  #~$20,MFP_ISRB            ; Clear interrupt-in-service
     move.l  (A7)+,D0                  ; Restore D0
 
     rte                               ; We're done


### PR DESCRIPTION
Fixes an issue whereby the system tick no longer worked on revision 1.x systems (#320).

The issue was that there was a bit of DUART code accidentally pulled into the new `rev1.asm` file. This was attempting to reset the DUART timer, and not clearing the ISR flag on the MFP leading to an apparent hang.

I have tested this change on both r1.23 board with MC68901 and AT28C256 ROMs and on r2.12 board with XR68C681 and SST39SF020 flash, and found it working on both. Would appreciate any further testing pre-merge.