### PR TITLE
Fix MAME ROM build for HUGEROM/Classic v2

### DIFF
--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -60,6 +60,11 @@ endif
 
 # Set up Size-specific things appropriately..
 ifeq ($(REVISION1X),true)
+ifeq ($(MAME),true)
+$(info === Building rosco_m68k firmware for MAME (rosco))
+LDFLAGS:=-T ./rosco_m68k_firmware_64k.ld -Map=$(MAP)
+MAMESIZE=0x00010000
+else
 ifeq ($(HUGEROM),true)
 $(info === Building rosco_m68k firmware for 1MB SST39SF040 (HUGEROM))
 LDFLAGS:=-T ./rosco_m68k_firmware_1M.ld -Map=$(MAP)
@@ -70,6 +75,13 @@ $(info === Building rosco_m68k firmware for 64KB AT28C256 (BIGROM))
 LDFLAGS:=-T ./rosco_m68k_firmware_64k.ld -Map=$(MAP)
 ROMDEVICE=AT28C256
 endif
+endif
+else
+ifeq ($(MAME),true)
+$(info === Building rosco_m68k firmware for MAME (rosco_classicv2))
+MAMESIZE=0x00100000
+LDFLAGS:=-T ./rosco_m68k_firmware_1M.ld -Map=$(MAP)
+DEFINES:=$(DEFINES) -DHUGEROM
 else
 ifeq ($(HUGEROM),false)
 $(error === Invalid option combination: Cannot build AT28C256 ROMs for r2.x boards!)
@@ -78,6 +90,7 @@ $(info === Building rosco_m68k firmware for 1MB SST39SF040 (HUGEROM))
 LDFLAGS:=-T ./rosco_m68k_firmware_1M.ld -Map=$(MAP)
 ROMDEVICE=SST39SF040
 DEFINES:=$(DEFINES) -DHUGEROM
+endif
 endif
 endif
 
@@ -125,7 +138,7 @@ export WITH_BLOCKDEV
 export WITH_KERMIT
 export CPU ARCH TUNE
 export REVISION1X
-
+export MAME
 
 %.o : %.c
 	$(CC) -c $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $<
@@ -173,6 +186,8 @@ burn: $(BINARY_EVEN) $(BINARY_ODD)
 tools: 
 	make -C tools/liblzg/src
 
+ifeq ($(MAME),true)
 mame: $(BINARY)
-	srec_cat -output $(BINARY_BASENAME)_mame.$(BINARY_EXT).bin -Binary $(BINARY) -Binary -fill 0xFF 0x00000000 0x00010000
+	srec_cat -output $(BINARY_BASENAME)_mame.$(BINARY_EXT).bin -Binary $(BINARY) -Binary -fill 0xFF 0x00000000 $(MAMESIZE)
+endif
 


### PR DESCRIPTION
Just fixing MAME ROM build to correctly generate 1MB ROM image for upcoming classic v2 support in MAME.

Build with `MAME=true make clean all` or `MAME=true REVISION1X=true make clean all`. 