### PR TITLE
Set GCC optimization parameter `min-pagesize=0`

### DIFF
--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -11,7 +11,7 @@ DEFINES:=$(DEFINES)
 CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Wpedantic -Werror	\
        -Iinclude -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE) -Os				\
        -fomit-frame-pointer -fno-delete-null-pointer-checks						\
-			 --param=min-pagesize=0 $(DEFINES)
+       --param=min-pagesize=0 $(DEFINES)
 LDFLAGS=-Map=$(MAP)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -11,7 +11,8 @@ DEFINES:=$(DEFINES)
 CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Wpedantic -Werror	\
        -Iinclude -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE) -Os				\
        -fomit-frame-pointer -fno-delete-null-pointer-checks						\
-			 -mno-align-int -mno-strict-align $(DEFINES)
+			 -mno-align-int -mno-strict-align --param=min-pagesize=0				\
+			 $(DEFINES)
 LDFLAGS=-Map=$(MAP)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/firmware/rosco_m68k_firmware/stage2/Makefile
+++ b/code/firmware/rosco_m68k_firmware/stage2/Makefile
@@ -7,10 +7,10 @@ CPU?=68010
 ARCH?=$(CPU)
 TUNE?=$(CPU)
 DEFINES=
-BASE_CFLAGS=-std=c11 -ffreestanding -Wno-unused-parameter     												\
-            -fomit-frame-pointer -Wall -Werror -Wpedantic -Wno-unused-function             \
+BASE_CFLAGS=-std=c11 -ffreestanding -Wno-unused-parameter     															\
+            -fomit-frame-pointer -Wall -Werror -Wpedantic -Wno-unused-function							\
             -Ifat_io_lib -Iinclude -I../include -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE)	\
-            $(DEFINES)
+            --param=min-pagesize=0 $(DEFINES)
 EXTRA_CFLAGS=
 CFLAGS=$(BASE_CFLAGS) -O9
 SIZE_CFLAGS=$(BASE_CFLAGS) -Os


### PR DESCRIPTION
Using the GCC optimization option parameter to set `min-pagesize` to `0` fixes the problem in #340, seemingly by not having literal pointers in the first page be considered offset from `NULL`.

Fixes #340 