### PR TITLE
Remove `-mno-strict-align` and `-mno-align-int`

### DIFF
--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -11,7 +11,7 @@ DEFINES:=$(DEFINES)
 CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Wpedantic -Werror	\
        -Iinclude -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE) -Os				\
        -fomit-frame-pointer -fno-delete-null-pointer-checks						\
-			 -mno-align-int -mno-strict-align $(DEFINES)
+       $(DEFINES)
 LDFLAGS=-Map=$(MAP)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 CC=m68k-elf-gcc

--- a/code/firmware/rosco_m68k_firmware/blockdev/include.mk
+++ b/code/firmware/rosco_m68k_firmware/blockdev/include.mk
@@ -11,7 +11,7 @@ EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DROSCO_M68K_SDCARD -DSD_BLOCK_READ_ONLY -DBLOCK
 ifeq ($(HUGEROM),true)
 BD_CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Wpedantic -Werror   \
           -Iinclude -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE) -O3         \
-          -fomit-frame-pointer -mno-align-int -mno-strict-align $(DEFINES)
+          -fomit-frame-pointer $(DEFINES)
 
 blockdev/mfp_gpio.o: blockdev/mfp_gpio.c
 	$(CC) -c $(BD_CFLAGS) $(EXTRA_CFLAGS) -o $@ $<

--- a/code/firmware/rosco_m68k_firmware/stage2/Makefile
+++ b/code/firmware/rosco_m68k_firmware/stage2/Makefile
@@ -8,9 +8,9 @@ ARCH?=$(CPU)
 TUNE?=$(CPU)
 DEFINES=
 BASE_CFLAGS=-std=c11 -ffreestanding -Wno-unused-parameter     												\
-       -fomit-frame-pointer -Wall -Werror -Wpedantic -Wno-unused-function             \
-			 -Ifat_io_lib -Iinclude -I../include -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE)	\
-			 -mno-align-int -mno-strict-align $(DEFINES)
+            -fomit-frame-pointer -Wall -Werror -Wpedantic -Wno-unused-function             \
+            -Ifat_io_lib -Iinclude -I../include -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE)	\
+            $(DEFINES)
 EXTRA_CFLAGS=
 CFLAGS=$(BASE_CFLAGS) -O9
 SIZE_CFLAGS=$(BASE_CFLAGS) -Os

--- a/code/firmware/rosco_m68k_firmware/stage2/kermit/include.mk
+++ b/code/firmware/rosco_m68k_firmware/stage2/kermit/include.mk
@@ -2,9 +2,9 @@ OBJECTS := $(OBJECTS) kermit/kermit.o kermit/kermit_support.o
 EXTRA_CFLAGS := $(EXTRA_CFLAGS) -Ikermit/include -DNODEBUG -DRECVONLY 		\
 	-DNO_CTRLC -DSTATIC=static -DKERMIT_LOADER	 
 KERMIT_CFLAGS=-std=c11 -ffreestanding -Wno-unused-parameter								\
-       -Wall -Werror -Wpedantic -Wno-unused-function -Os               		\
-			 -Iinclude -I../include -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE)	\
-			 -mno-align-int -mno-strict-align $(DEFINES)
+              -Wall -Werror -Wpedantic -Wno-unused-function -Os               		\
+              -Iinclude -I../include -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE)	\
+              $(DEFINES)
 
 kermit/kermit.o: kermit/kermit.c
 	$(CC) $(KERMIT_CFLAGS) $(EXTRA_CFLAGS) -c -o $@ $<

--- a/code/firmware/rosco_m68k_firmware/stage2/sdfat/include.mk
+++ b/code/firmware/rosco_m68k_firmware/stage2/sdfat/include.mk
@@ -5,10 +5,10 @@ EXTRA_CFLAGS := $(EXTRA_CFLAGS)																								\
 		-Isdfat/include
 
 BBSD_CFLAGS=-std=c11 -ffreestanding -Wno-unused-parameter		                	\
-			      -Wall -Werror -Wpedantic -Wno-unused-function                   	\
+            -Wall -Werror -Wpedantic -Wno-unused-function                   	\
             -I../include -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE)						\
             -DROSCO_M68K -I../blockdev/include																\
-            -mno-align-int -mno-strict-align $(DEFINES) -DSDFAT_LOADER
+            $(DEFINES) -DSDFAT_LOADER
 								
 sdfat/load.o: sdfat/load.c
 	$(CC) $(BBSD_CFLAGS) $(EXTRA_CFLAGS) -c -o $@ $<

--- a/code/software/sdfat_demo/Makefile
+++ b/code/software/sdfat_demo/Makefile
@@ -15,8 +15,8 @@ GCC_LIBS=$(shell $(CC) --print-search-dirs 															\
     | sed 's/:/m68000\/ -L/g')m68000/
 DEFINES=-DROSCO_M68K
 CFLAGS=-std=c11 -ffreestanding -Wall -pedantic -Werror -I$(SYSINCDIR) 	\
-			 -mcpu=68010 -march=68010 -mtune=68010 -Wno-unused-function				\
-			 -mno-align-int -mno-strict-align $(DEFINES)
+       -mcpu=68010 -march=68010 -mtune=68010 -Wno-unused-function				\
+       $(DEFINES)
 
 ifneq ($(ROSCO_M68K_HUGEROM),false)
 LDSCRIPT?=$(SYSLIBDIR)/ld/serial/hugerom_rosco_m68k_program.ld


### PR DESCRIPTION
The option `-mno-strict-align` allows GCC to misalign values. In GCC 12.2, with `-mno-strict-align`, I've had issues appear where optimizations convert a "safe" unaligned word load (reading and shifting individual bytes) to a single word load, causing an address error.

`-mno-strict-align` causes GCC to assume that misaligned accesses are handled by the system.

`-mno-align-int` is also removed; that seems to be the default in the compiler anyways, since the opposite (`-malign-int`) is ABI-breaking.