### PR TITLE
Don't use custom build options for `stage2/load/load.o`

### DIFF
--- a/code/firmware/rosco_m68k_firmware/stage2/load/include.mk
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/include.mk
@@ -4,8 +4,4 @@ OBJECTS := $(OBJECTS) load/load.o																						\
 	load/fat_io_lib/fat_misc.o load/fat_io_lib/fat_string.o										\
 	load/fat_io_lib/fat_table.o load/fat_io_lib/fat_write.o
 
-EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DFATFS_USE_CUSTOM_OPTS_FILE								\
-		-Iload/include -I../include
-		
-load/load.o: load/load.c
-	$(CC) $(EXTRA_CFLAGS) -c -o $@ $<
+EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DFATFS_USE_CUSTOM_OPTS_FILE -Iload/include

--- a/code/firmware/rosco_m68k_firmware/stage2/load/load.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/load.c
@@ -84,7 +84,7 @@ bool load_kernel(PartHandle *part) {
             fl_attach_media(media_read, media_write);
 
             void *file;
-            if (file = fl_fopen(FILENAME_BIN, "r")) {
+            if ((file = fl_fopen(FILENAME_BIN, "r"))) {
                 mcPrint("Loading \"");
                 mcPrint(FILENAME_BIN);
                 mcPrint("\"");


### PR DESCRIPTION
When I unified loading the kernel in one spot, instead of duplicating code, I misunderstood the structure of the `include.mk` files, so `stage2/load/load.o` was being built without the right command-line options.

This led to GCC possibly generating MC68020+ opcodes, as encountered by SteveGG on Discord. The warning/error options were also not being included.

This PR leaves `stage2/load/load.o` to be built with the default pattern from the general `stage2` `Makefile`.

---

While this fixes the immediate issue, I would like to separately do a little cleanup in the firmware, both for any Makefiles that need it, and with the `extern` declarations, which could be put into headers.