### PR TITLE
Actually fix #340 properly, don't break on GCC pre-11.3 builds

### DIFF
--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -11,7 +11,7 @@ DEFINES:=$(DEFINES)
 CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Wpedantic -Werror	\
        -Iinclude -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE) -Os				\
        -fomit-frame-pointer -fno-delete-null-pointer-checks						\
-       --param=min-pagesize=0 $(DEFINES)
+       $(DEFINES)
 LDFLAGS=-Map=$(MAP)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 CC=m68k-elf-gcc
@@ -22,6 +22,14 @@ OBJDUMP=m68k-elf-objdump
 SIZE=m68k-elf-size
 NM=m68k-elf-nm
 RM=rm -f
+
+# If this is GCC 12, add flag --param=min-pagesize=0
+ifneq ($(findstring GCC,$(shell $(CC) --version 2>/dev/null)),)
+CC_VERSION:=$(shell $(CC) -dumpfullversion)
+ifeq ($(firstword $(subst ., ,$(CC_VERSION))),12)
+CFLAGS+=--param=min-pagesize=0
+endif
+endif
 
 # Output config
 BINARY_BASENAME=rosco_m68k

--- a/code/firmware/rosco_m68k_firmware/stage2/Makefile
+++ b/code/firmware/rosco_m68k_firmware/stage2/Makefile
@@ -10,7 +10,7 @@ DEFINES=
 BASE_CFLAGS=-std=c11 -ffreestanding -Wno-unused-parameter     															\
             -fomit-frame-pointer -Wall -Werror -Wpedantic -Wno-unused-function							\
             -Ifat_io_lib -Iinclude -I../include -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE)	\
-            --param=min-pagesize=0 $(DEFINES)
+            $(DEFINES)
 EXTRA_CFLAGS=
 CFLAGS=$(BASE_CFLAGS) -O9
 SIZE_CFLAGS=$(BASE_CFLAGS) -Os
@@ -20,6 +20,14 @@ CC=m68k-elf-gcc
 LD=m68k-elf-ld
 AS=vasmm68k_mot
 RM=rm -f
+
+# If this is GCC 12, add flag --param=min-pagesize=0
+ifneq ($(findstring GCC,$(shell $(CC) --version 2>/dev/null)),)
+CC_VERSION:=$(shell $(CC) -dumpfullversion)
+ifeq ($(firstword $(subst ., ,$(CC_VERSION))),12)
+BASE_CFLAGS+=--param=min-pagesize=0
+endif
+endif
 
 # Output config
 BINARY_BASENAME=loader2


### PR DESCRIPTION
As caught by SteveGG on discord, `--param=min-pagesize=0` is not valid with some older versions of GCC, including 11.2, breaking builds (oops :sweat_smile:). This commit only enables that flag on major version 12 of GCC, where the problem being fixed is present. While it seems that the flag has been backported as a part of GCC 11.3, the recommended toolchain is still on 11.2.

I'm not a fan of enabling flags depending on the compiler version, but it seems needed here, and this is the approach taken by some other projects. Disabling the warnings/errors themselves could lead to real problems being missed. From the GCC bugtracker, a more complete solution is coming in GCC 13, but that isn't released yet, and would require updating anyways.

---

Another option would be to not make the address directly visible to the compiler, using `extern` variables and the linker  script providing the addresses, but this would involve restructuring a lot more. This could be a good option in the future if some of the existing `extern` declarations are consolidated.