### PR TITLE
Fix issues introduced by GCC 13

### DIFF
--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -23,10 +23,15 @@ SIZE=m68k-elf-size
 NM=m68k-elf-nm
 RM=rm -f
 
-# If this is GCC 12, add flag --param=min-pagesize=0
+# GCC-version-specific settings
 ifneq ($(findstring GCC,$(shell $(CC) --version 2>/dev/null)),)
 CC_VERSION:=$(shell $(CC) -dumpfullversion)
-ifeq ($(firstword $(subst ., ,$(CC_VERSION))),12)
+CC_MAJOR:=$(firstword $(subst ., ,$(CC_VERSION)))
+# If this is GCC 12 or 13, add flag --param=min-pagesize=0 to CFLAGS
+ifeq ($(CC_MAJOR),12)
+CFLAGS+=--param=min-pagesize=0
+endif
+ifeq ($(CC_MAJOR),13)
 CFLAGS+=--param=min-pagesize=0
 endif
 endif

--- a/code/firmware/rosco_m68k_firmware/stage2/Makefile
+++ b/code/firmware/rosco_m68k_firmware/stage2/Makefile
@@ -21,11 +21,16 @@ LD=m68k-elf-ld
 AS=vasmm68k_mot
 RM=rm -f
 
-# If this is GCC 12, add flag --param=min-pagesize=0
+# GCC-version-specific settings
 ifneq ($(findstring GCC,$(shell $(CC) --version 2>/dev/null)),)
 CC_VERSION:=$(shell $(CC) -dumpfullversion)
-ifeq ($(firstword $(subst ., ,$(CC_VERSION))),12)
-BASE_CFLAGS+=--param=min-pagesize=0
+CC_MAJOR:=$(firstword $(subst ., ,$(CC_VERSION)))
+# If this is GCC 12 or 13, add flag --param=min-pagesize=0 to CFLAGS
+ifeq ($(CC_MAJOR),12)
+CFLAGS+=--param=min-pagesize=0
+endif
+ifeq ($(CC_MAJOR),13)
+CFLAGS+=--param=min-pagesize=0
 endif
 endif
 

--- a/code/software/libs/src/libm/include.mk
+++ b/code/software/libs/src/libm/include.mk
@@ -12,6 +12,16 @@ OBJECTS := $(OBJECTS) $(LIBOBJECTS)
 INCLUDES := $(INCLUDES) $(DIR)/include/*
 LIBS := $(LIBS) $(DIR)/$(BINARY)
 
+# GCC-version-specific settings
+ifneq ($(findstring GCC,$(shell $(CC) --version 2>/dev/null)),)
+CC_VERSION:=$(shell $(CC) -dumpfullversion)
+CC_MAJOR:=$(firstword $(subst ., ,$(CC_VERSION)))
+# If this is GCC 13, add flag -Wno-error=maybe-uninitialized
+ifeq ($(CC_MAJOR),13)
+CFLAGS+=-Wno-error=maybe-uninitialized
+endif
+endif
+
 $(DIR)/$(BINARY): $(LIBOBJECTS)
 	$(AR)	$(ARFLAGS) rs $@ $^
 	$(RANLIB) $@


### PR DESCRIPTION
This pull request fixes #346, where GCC 13 needs the `--param=min-pagesize=0` parameter to allow accesses that appear to be in the `NULL` page, as with GCC 12.
For now, this is implemented as a second major version check. If this is needed for all future versions, a `>=` comparison could be used.

Additionally, GCC 13 appears to introduce a false-positive error in libm, so `-Wno-error=maybe-uninitialized` is added.