### PR TITLE
Fix `LOAD` segments having RWX permissions

### DIFF
--- a/code/software/ehbasic/ehbasic.asm
+++ b/code/software/ehbasic/ehbasic.asm
@@ -9236,7 +9236,7 @@ LAB_SMSG
 * MID$	. MID$(<sexpr>,<nexpr>[,<nexpr>])				* done
 * USING$	. USING$(<sexpr>,<nexpr>[,<nexpr>]...])			* done
 
-	section .data
+	section .data,data
     align   12
 FREE_MEM:
 	

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -130,7 +130,7 @@ CALL_DTORS::
     movem.l (A7)+,A2-A4
     rts
 
-    section .data
+    section .bss,bss
     align  4
 
 SAVE_PROG_EXIT  ds.l  1

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -17,11 +17,12 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
 
-ram  = 0x00002000;          /* start of user memory                     */
+ram       = 0x00000000;                 /* start of RAM                 */
+user_ram  = 0x00002000;                 /* start of user memory         */
 
 MEMORY
 {
-  RAM  : org = ram,  l = 0x00f7e000     /* program can use all RAM > 8K */
+  RAM  : org = ram,  l = 0x00f80000     /* program can use all RAM > 8K */
 }
 
 /* program configuration symbols that may be useful to override */
@@ -86,11 +87,11 @@ PROVIDE(_FIRMWARE_REV   = 0x00E00400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = ORIGIN(RAM)); /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = user_ram);    /* start of user memory         */
 
 SECTIONS
 {
-  .text.init :
+  .text.init _RUN_ADDRESS : AT(_LOAD_ADDRESS)
   {
     _init = .;
     KEEP(*(.init))      /* KEEP() "anchors" section for gc-sections */

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -17,12 +17,12 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
 
-ram       = 0x00000000;                 /* start of RAM                 */
-user_ram  = 0x00002000;                 /* start of user memory         */
-
 MEMORY
 {
-  RAM  : org = ram,  l = 0x00f80000     /* program can use all RAM > 8K */
+  RAM       : org = 0x00000000,  l = 0x00100000
+  EXP_RAM   : org = 0x00100000,  l = 0x00D00000
+  ROM       : org = 0x00E00000,  l = 0x00100000
+  IO_SPACE  : org = 0x00F00000,  l = 0x00100000
 }
 
 /* program configuration symbols that may be useful to override */
@@ -87,7 +87,7 @@ PROVIDE(_FIRMWARE_REV   = 0x00E00400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = user_ram);    /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = 0x00002000);    /* start of user memory         */
 
 SECTIONS
 {

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -98,7 +98,7 @@ SECTIONS
     _init_end = .;
   } > RAM
 
-  .text.postinit :
+  .text.postinit ALIGN(4) :
   {
     _postinit = .;
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
@@ -114,7 +114,9 @@ SECTIONS
     _code_end = .;
   } > RAM
 
-  .ctors ALIGN(4) : 
+  . = DATA_SEGMENT_ALIGN(CONSTANT(MAXPAGESIZE), CONSTANT(COMMONPAGESIZE));
+
+  .ctors ALIGN(4) :
   {
       _ctors = .;
       KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
@@ -138,15 +140,16 @@ SECTIONS
     _data_end = .;
   } > RAM
 
-  .bss(NOLOAD):
+  .bss ALIGN(4) :
   {
-    . = ALIGN(4);       /* Not strictly needed, but here in case we rearrange things */
     _bss_start = .;
     *(.bss*)
     *(COMMON)
     . = ALIGN(4);       /* long align for kinit clearing */
     _bss_end = .;
   } > RAM
+
+  . = DATA_SEGMENT_END(.);
 
   _end = .;
 }

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -87,7 +87,7 @@ PROVIDE(_FIRMWARE_REV   = 0x00E00400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = 0x00002000);    /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = 0x00002000);  /* start of user memory         */
 
 SECTIONS
 {

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -96,7 +96,7 @@ SECTIONS
     _init = .;
     KEEP(*(.init))      /* KEEP() "anchors" section for gc-sections */
     _init_end = .;
-  } > RAM
+  } >RAM
 
   .text.postinit ALIGN(4) :
   {
@@ -104,7 +104,7 @@ SECTIONS
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
     . = ALIGN(4);       /* long align for init.S copying */
     _postinit_end = .;
-  } > RAM
+  } >RAM
 
   .text ALIGN(4) :
   {
@@ -112,7 +112,7 @@ SECTIONS
     *(.text*)
     *(.rodata*)
     _code_end = .;
-  } > RAM
+  } >RAM
 
   . = DATA_SEGMENT_ALIGN(CONSTANT(MAXPAGESIZE), CONSTANT(COMMONPAGESIZE));
 
@@ -122,7 +122,7 @@ SECTIONS
       KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
       KEEP(*(SORT(.ctors.*)))   /* followed by ctors with priority */
       _ctors_end = .;
-  } > RAM
+  } >RAM
 
   .dtors ALIGN(4) : 
   {
@@ -130,7 +130,7 @@ SECTIONS
       KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first */
       KEEP(*(.dtors))           /* Followed by non-priority ones */
       _dtors_end = .;
-  } > RAM
+  } >RAM
 
   .data ALIGN(4) :
   {
@@ -138,7 +138,7 @@ SECTIONS
     *(.data*)
     . = ALIGN(4);       /* long align for init.S copying */
     _data_end = .;
-  } > RAM
+  } >RAM
 
   .bss ALIGN(4) :
   {
@@ -147,7 +147,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN(4);       /* long align for kinit clearing */
     _bss_end = .;
-  } > RAM
+  } >RAM
 
   . = DATA_SEGMENT_END(.);
 

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -96,7 +96,7 @@ SECTIONS
     _init = .;
     KEEP(*(.init))      /* KEEP() "anchors" section for gc-sections */
     _init_end = .;
-  } > RAM
+  } >RAM
 
   .text.postinit ALIGN(4) :
   {
@@ -104,7 +104,7 @@ SECTIONS
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
     . = ALIGN(4);       /* long align for init.S copying */
     _postinit_end = .;
-  } > RAM
+  } >RAM
 
   .text ALIGN(4) :
   {
@@ -112,7 +112,7 @@ SECTIONS
     *(.text*)
     *(.rodata*)
     _code_end = .;
-  } > RAM
+  } >RAM
 
   . = DATA_SEGMENT_ALIGN(CONSTANT(MAXPAGESIZE), CONSTANT(COMMONPAGESIZE));
 
@@ -122,7 +122,7 @@ SECTIONS
       KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
       KEEP(*(SORT(.ctors.*)))   /* followed by ctors with priority */
       _ctors_end = .;
-  } > RAM
+  } >RAM
 
   .dtors ALIGN(4) : 
   {
@@ -130,7 +130,7 @@ SECTIONS
       KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first, highest to lowest */
       KEEP(*(.dtors))           /* Followed by non-priority ones */
       _dtors_end = .;
-  } > RAM
+  } >RAM
 
   .data ALIGN(4) :
   {
@@ -138,7 +138,7 @@ SECTIONS
     *(.data*)
     . = ALIGN(4);       /* long align for init.S copying */
     _data_end = .;
-  } > RAM
+  } >RAM
 
   .bss ALIGN(4) :
   {
@@ -147,7 +147,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN(4);       /* long align for kinit clearing */
     _bss_end = .;
-  } > RAM
+  } >RAM
 
   . = DATA_SEGMENT_END(.);
 

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -17,12 +17,12 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
 
-ram       = 0x00000000;                 /* start of RAM                 */
-user_ram  = 0x00002000;                 /* start of user memory         */
-
 MEMORY
 {
-  RAM  : org = ram,  l = 0x00f80000     /* program can use all RAM > 8K */
+  RAM       : org = 0x00000000,  l = 0x00100000
+  EXP_RAM   : org = 0x00100000,  l = 0x00E80000
+  IO_SPACE  : org = 0x00F80000,  l = 0x00040000
+  ROM       : org = 0x00FC0000,  l = 0x00040000
 }
 
 /* program configuration symbols that may be useful to override */
@@ -87,7 +87,7 @@ PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = user_ram);    /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = 0x00002000);    /* start of user memory         */
 
 SECTIONS
 {

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -17,11 +17,12 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
 
-ram  = 0x00002000;          /* start of user memory                     */
+ram       = 0x00000000;                 /* start of RAM                 */
+user_ram  = 0x00002000;                 /* start of user memory         */
 
 MEMORY
 {
-  RAM  : org = ram,  l = 0x00f7e000     /* program can use all RAM > 8K */
+  RAM  : org = ram,  l = 0x00f80000     /* program can use all RAM > 8K */
 }
 
 /* program configuration symbols that may be useful to override */
@@ -86,7 +87,7 @@ PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = ORIGIN(RAM)); /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = user_ram);    /* start of user memory         */
 
 SECTIONS
 {

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -98,7 +98,7 @@ SECTIONS
     _init_end = .;
   } > RAM
 
-  .text.postinit :
+  .text.postinit ALIGN(4) :
   {
     _postinit = .;
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
@@ -113,8 +113,10 @@ SECTIONS
     *(.rodata*)
     _code_end = .;
   } > RAM
-  
-  .ctors ALIGN(4) : 
+
+  . = DATA_SEGMENT_ALIGN(CONSTANT(MAXPAGESIZE), CONSTANT(COMMONPAGESIZE));
+
+  .ctors ALIGN(4) :
   {
       _ctors = .;
       KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
@@ -138,15 +140,16 @@ SECTIONS
     _data_end = .;
   } > RAM
 
-  .bss(NOLOAD):
+  .bss ALIGN(4) :
   {
-    . = ALIGN(4);       /* Not strictly needed, but here in case we rearrange things */
     _bss_start = .;
     *(.bss*)
     *(COMMON)
     . = ALIGN(4);       /* long align for kinit clearing */
     _bss_end = .;
   } > RAM
+
+  . = DATA_SEGMENT_END(.);
 
   _end = .;
 }

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -87,7 +87,7 @@ PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = 0x00002000);    /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = 0x00002000);  /* start of user memory         */
 
 SECTIONS
 {

--- a/code/software/memcheck/funcs.asm
+++ b/code/software/memcheck/funcs.asm
@@ -105,7 +105,7 @@ RESTORE_BERR_HANDLER::
     move.l  SAVEDHANDLER,$8
     rts
 
-    section .data
+    section .data,data
     align   2
 SAVEDHANDLER    dc.l  0
 

--- a/code/software/software.mk
+++ b/code/software/software.mk
@@ -37,21 +37,6 @@ ASFLAGS=-mcpu=$(CPU) -march=$(ARCH)
 VASMFLAGS=-Felf -m$(CPU) -quiet -Lnf $(DEFINES)
 LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 
-ifeq ($(CPU),68030)
-LD_LD_SUPPORT_MMU?=true
-endif
-ifeq ($(CPU),68040)
-LD_SUPPORT_MMU?=true
-endif
-ifeq ($(CPU),68060)
-LD_SUPPORT_MMU?=true
-endif
-LD_SUPPORT_MMU?=false
-ifneq ($(LD_SUPPORT_MMU),true)
-# Saves space in binaries, but will break MMU use
-LDFLAGS+=-z max-page-size=16 -z common-page-size=16
-endif
-
 CC=m68k-elf-gcc
 CXX=m68k-elf-g++
 AS=m68k-elf-as
@@ -79,6 +64,21 @@ endif
 ifeq ($(CC_MAJOR),13)
 CFLAGS+=--param=min-pagesize=0
 endif
+endif
+
+ifeq ($(CPU),68030)
+LD_LD_SUPPORT_MMU?=true
+endif
+ifeq ($(CPU),68040)
+LD_SUPPORT_MMU?=true
+endif
+ifeq ($(CPU),68060)
+LD_SUPPORT_MMU?=true
+endif
+LD_SUPPORT_MMU?=false
+ifneq ($(LD_SUPPORT_MMU),true)
+# Saves space in binaries, but will break MMU use
+LDFLAGS+=-z max-page-size=16 -z common-page-size=16
 endif
 
 # Output config (assume name of directory)

--- a/code/software/software.mk
+++ b/code/software/software.mk
@@ -37,17 +37,17 @@ ASFLAGS=-mcpu=$(CPU) -march=$(ARCH)
 VASMFLAGS=-Felf -m$(CPU) -quiet -Lnf $(DEFINES)
 LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 
-ifeq ($(CPU),68000)
-LD_SMALL_PAGES?=true
+ifeq ($(CPU),68030)
+LD_LD_SUPPORT_MMU?=true
 endif
-ifeq ($(CPU),68010)
-LD_SMALL_PAGES?=true
+ifeq ($(CPU),68040)
+LD_SUPPORT_MMU?=true
 endif
-ifeq ($(CPU),68020)
-LD_SMALL_PAGES?=true
+ifeq ($(CPU),68060)
+LD_SUPPORT_MMU?=true
 endif
-LD_SMALL_PAGES?=false
-ifeq ($(LD_SMALL_PAGES),true)
+LD_SUPPORT_MMU?=false
+ifneq ($(LD_SUPPORT_MMU),true)
 # Saves space in binaries, but will break MMU use
 LDFLAGS+=-z max-page-size=16 -z common-page-size=16
 endif

--- a/code/software/software.mk
+++ b/code/software/software.mk
@@ -37,6 +37,21 @@ ASFLAGS=-mcpu=$(CPU) -march=$(ARCH)
 VASMFLAGS=-Felf -m$(CPU) -quiet -Lnf $(DEFINES)
 LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k
 
+ifeq ($(CPU),68000)
+LD_SMALL_PAGES?=true
+endif
+ifeq ($(CPU),68010)
+LD_SMALL_PAGES?=true
+endif
+ifeq ($(CPU),68020)
+LD_SMALL_PAGES?=true
+endif
+LD_SMALL_PAGES?=false
+ifeq ($(LD_SMALL_PAGES),true)
+# Saves space in binaries, but will break MMU use
+LDFLAGS+=-z max-page-size=16 -z common-page-size=16
+endif
+
 CC=m68k-elf-gcc
 CXX=m68k-elf-g++
 AS=m68k-elf-as

--- a/code/software/software.mk
+++ b/code/software/software.mk
@@ -66,6 +66,8 @@ CFLAGS+=--param=min-pagesize=0
 endif
 endif
 
+# For systems without MMU support, aligning LOAD segments with pages is not needed
+# In those cases, provide fake page sizes to both save space and remove RWX warnings
 ifeq ($(CPU),68030)
 LD_LD_SUPPORT_MMU?=true
 endif

--- a/code/software/tests/cpuinfo/kmain.asm
+++ b/code/software/tests/cpuinfo/kmain.asm
@@ -112,12 +112,12 @@ IIHANDLER:
     move.l  CONTADDR,(2,A7)           ; Update continue PC
     rte
 
-    section .rodata
+    section .rodata,text
 MODULE    dc.l    $0                  ; Option 0, Type 0, Rest ignored
           dc.l    MODENTRY            ; Entry word at MODENTRY
 SZCPU     dc.b    'MC680', 0
 
-    section .bss
+    section .bss,bss
 M16BUF    ds.l    4
 IISAVED   ds.l    1
 FLSAVED   ds.l    1


### PR DESCRIPTION
This PR fixes the `ld` warnings reported by Xark on Discord, such as:
```
warning: starter_c.elf has a LOAD segment with RWX permissions
```

This is caused by there being LOAD segments in the generated program that have both write and execute permissions, which could facilitate security exploits in programs. While these warnings are harmless here (we don't have an MMU yet to enforce permissions anyways), they are annoying. They can be suppressed with `--no-warn-rwx-segment` added to `LDFLAGS`, but this only hides the issue.

In this PR, I fix a couple few assembly files where the sections weren't being set to the right type. In vasm, the `data` is equivalent to `section .data,data`, instead of `section .data`. The former sets the section to have the properties of a data section, instead of a text one. This change prevents the `.data` and `.bss` from themselves becoming RWX.

The second cause of the issue here is that both text and data were being placed in the same pages in memory, which causes those pages to have permissions that are the union of those sections' permissions. To fix this, maximum-page-size-alignment is added between the text and data, to allow the linker to assign them different permissions.

Originally this wasted up to `0x1FFF` bytes of space in the binaries, but this was fixed by overriding the maximum page size to a smaller value. This will break loading in a system using an MMU, but saves considerable space. By default, this space saving is disabled for the '030, '040, and '060, which have version that include an MMU.