### PR TITLE
updateflash from SD fix (ROM_BIN not defined)

### DIFF
--- a/code/software/updateflash/Makefile
+++ b/code/software/updateflash/Makefile
@@ -12,8 +12,9 @@ else
 $(info NOTE: Using ROSCO_M68K_DIR libs in: $(ROSCO_M68K_DIR))
 endif
 
-ROM_OBJ=rosco_rom.o
+ROM_BIN?=
 ifneq ($(ROM_BIN),)
+ROM_OBJ=rosco_rom.o
 $(info NOTE: Embedding ROM firmware image in $(ELF) binary: $(ROM_BIN))
 
 # Having this define in EXTRA_CFLAGS is a hack around an issue with
@@ -23,13 +24,15 @@ $(info NOTE: Embedding ROM firmware image in $(ELF) binary: $(ROM_BIN))
 EXTRA_CFLAGS=-DFIRMWARE_EMBEDDED
 
 OBJECTS+=$(ROM_OBJ)
-endif
 TO_CLEAN+=rosco_rom.bin $(ROM_OBJ)
+endif
 
 -include $(ROSCO_M68K_DIR)/code/software/software.mk
 
 EXTRA_LIBS=-lsdfat -lsst_flash
 
+ifneq ($(ROM_BIN),)
 $(ROM_OBJ): $(ROM_BIN)
 	$(CP) $(ROM_BIN) rosco_rom.bin
 	$(OBJCOPY) -I binary -O elf32-m68k -B m68k:68000 rosco_rom.bin $@
+endif


### PR DESCRIPTION
Fix minor Makefile issue causing cp error when ROM_BIN not defined (e.g., update flash from ROM image on SD card, vs embedded in binary).