### PR TITLE
Feature/firmware-s-assemble-fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: CI Build on PR
+on: 
+  push:
+    branches-ignore:
+      - 'master'
+      - 'develop'
+      - 'release/*'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: roscopeco/rosco_m68k:latest
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@v1
+        - name: Hack GITHUB_WORKSPACE 🥷
+          run: |
+            sudo chown -R linuxbrew "$GITHUB_WORKSPACE"
+        - name: Generate build stamp & artifact output
+          run: |
+            date +%Y%m%d_%H%M%S > "$GITHUB_WORKSPACE/stamp.txt"
+            git rev-parse --short HEAD > "$GITHUB_WORKSPACE/branch.txt"
+            mkdir "$GITHUB_WORKSPACE/artifacts"
+        - name: Build software & install libs
+          run: |
+            cd code/software/libs
+            make clean install
+            cd ..
+            tar czf rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_stdlibs.tar.gz libs
+            cp rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_stdlibs.tar.gz "$GITHUB_WORKSPACE/artifacts"
+            make clean all
+        - name: Build firmware - r2 Base
+          run: |
+            cd code/firmware/rosco_m68k_firmware
+            make clean all
+            tar czf rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_2.x.tar.gz *.rom
+            cp rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_2.x.tar.gz "$GITHUB_WORKSPACE/artifacts"
+        - name: Build firmware - r2 Flash
+          run: |
+            cd code/software/updateflash
+            ROM_BIN=../../firmware/rosco_m68k_firmware/rosco_m68k.rom make clean all
+            cp updateflash.bin "$GITHUB_WORKSPACE"/artifacts/rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_2.x_flash.bin
+        - name: Build firmware - r2 MAME
+          run: |
+            cd code/firmware/rosco_m68k_firmware
+            MAME=true make clean all mame
+            tar czf rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_2.x_mame.tar.gz rosco_m68k.rom rosco_m68k_mame.rom.bin
+            cp rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_2.x_mame.tar.gz "$GITHUB_WORKSPACE/artifacts"
+        - name: Build firmware - r1 Big
+          run: |
+            cd code/firmware/rosco_m68k_firmware
+            REVISION1X=true HUGEROM=false make clean all
+            tar czf rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_1.x_64kb.tar.gz *.rom
+            cp rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_1.x_64kb.tar.gz "$GITHUB_WORKSPACE/artifacts"
+        - name: Build firmware - r1 Huge
+          run: |
+            cd code/firmware/rosco_m68k_firmware
+            REVISION1X=true HUGEROM=true make clean all
+            tar czf rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_1.x_hugerom.tar.gz *.rom
+            cp rosco_m68k_fw_$(cat "$GITHUB_WORKSPACE/branch.txt")_$(cat "$GITHUB_WORKSPACE/stamp.txt")_mainboard_1.x_hugerom.tar.gz "$GITHUB_WORKSPACE/artifacts"
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: build-snapshots
+            path: artifacts/
+

--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -169,6 +169,9 @@ export MAME
 %.o : %.asm
 	$(AS) $(ASFLAGS) -o $@ $<
 
+%.o : %.s
+	$(AS) $(ASFLAGS) -o $@ $<
+
 $(STAGE2) : $(STAGE2_DIR)
 	CPU='$(CPU)' ARCH='$(ARCH)' TUNE='$(TUNE)' make -C $^ $(STAGE2_FILE)
 

--- a/code/software/ehbasic/ehbasic.asm
+++ b/code/software/ehbasic/ehbasic.asm
@@ -9236,7 +9236,7 @@ LAB_SMSG
 * MID$	. MID$(<sexpr>,<nexpr>[,<nexpr>])				* done
 * USING$	. USING$(<sexpr>,<nexpr>[,<nexpr>]...])			* done
 
-	section .data
+	section .data,data
     align   12
 FREE_MEM:
 	

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -130,7 +130,7 @@ CALL_DTORS::
     movem.l (A7)+,A2-A4
     rts
 
-    section .data
+    section .bss,bss
     align  4
 
 SAVE_PROG_EXIT  ds.l  1

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -17,11 +17,12 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
 
-ram  = 0x00002000;          /* start of user memory                     */
-
 MEMORY
 {
-  RAM  : org = ram,  l = 0x00f7e000     /* program can use all RAM > 8K */
+  RAM       : org = 0x00000000,  l = 0x00100000
+  EXP_RAM   : org = 0x00100000,  l = 0x00D00000
+  ROM       : org = 0x00E00000,  l = 0x00100000
+  IO_SPACE  : org = 0x00F00000,  l = 0x00100000
 }
 
 /* program configuration symbols that may be useful to override */
@@ -86,24 +87,24 @@ PROVIDE(_FIRMWARE_REV   = 0x00E00400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = ORIGIN(RAM)); /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = 0x00002000);  /* start of user memory         */
 
 SECTIONS
 {
-  .text.init :
+  .text.init _RUN_ADDRESS : AT(_LOAD_ADDRESS)
   {
     _init = .;
     KEEP(*(.init))      /* KEEP() "anchors" section for gc-sections */
     _init_end = .;
-  } > RAM
+  } >RAM
 
-  .text.postinit :
+  .text.postinit ALIGN(4) :
   {
     _postinit = .;
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
     . = ALIGN(4);       /* long align for init.S copying */
     _postinit_end = .;
-  } > RAM
+  } >RAM
 
   .text ALIGN(4) :
   {
@@ -111,15 +112,17 @@ SECTIONS
     *(.text*)
     *(.rodata*)
     _code_end = .;
-  } > RAM
+  } >RAM
 
-  .ctors ALIGN(4) : 
+  . = DATA_SEGMENT_ALIGN(CONSTANT(MAXPAGESIZE), CONSTANT(COMMONPAGESIZE));
+
+  .ctors ALIGN(4) :
   {
       _ctors = .;
       KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
       KEEP(*(SORT(.ctors.*)))   /* followed by ctors with priority */
       _ctors_end = .;
-  } > RAM
+  } >RAM
 
   .dtors ALIGN(4) : 
   {
@@ -127,7 +130,7 @@ SECTIONS
       KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first */
       KEEP(*(.dtors))           /* Followed by non-priority ones */
       _dtors_end = .;
-  } > RAM
+  } >RAM
 
   .data ALIGN(4) :
   {
@@ -135,17 +138,18 @@ SECTIONS
     *(.data*)
     . = ALIGN(4);       /* long align for init.S copying */
     _data_end = .;
-  } > RAM
+  } >RAM
 
-  .bss(NOLOAD):
+  .bss ALIGN(4) :
   {
-    . = ALIGN(4);       /* Not strictly needed, but here in case we rearrange things */
     _bss_start = .;
     *(.bss*)
     *(COMMON)
     . = ALIGN(4);       /* long align for kinit clearing */
     _bss_end = .;
-  } > RAM
+  } >RAM
+
+  . = DATA_SEGMENT_END(.);
 
   _end = .;
 }

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -17,11 +17,12 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
 
-ram  = 0x00002000;          /* start of user memory                     */
-
 MEMORY
 {
-  RAM  : org = ram,  l = 0x00f7e000     /* program can use all RAM > 8K */
+  RAM       : org = 0x00000000,  l = 0x00100000
+  EXP_RAM   : org = 0x00100000,  l = 0x00E80000
+  IO_SPACE  : org = 0x00F80000,  l = 0x00040000
+  ROM       : org = 0x00FC0000,  l = 0x00040000
 }
 
 /* program configuration symbols that may be useful to override */
@@ -86,7 +87,7 @@ PROVIDE(_FIRMWARE_REV   = 0x00FC0400);  /* firmware revision code       */
 
 /* NOTE: rev1.1 used 0x00028000 (but init now position independent)     */
 PROVIDE(_LOAD_ADDRESS   = 0x00040000);  /* firmware KERNEL_LOAD_ADDRESS */
-PROVIDE(_RUN_ADDRESS    = ORIGIN(RAM)); /* start of user memory         */
+PROVIDE(_RUN_ADDRESS    = 0x00002000);  /* start of user memory         */
 
 SECTIONS
 {
@@ -95,15 +96,15 @@ SECTIONS
     _init = .;
     KEEP(*(.init))      /* KEEP() "anchors" section for gc-sections */
     _init_end = .;
-  } > RAM
+  } >RAM
 
-  .text.postinit :
+  .text.postinit ALIGN(4) :
   {
     _postinit = .;
     KEEP(*(.postinit))  /* KEEP() "anchors" section for gc-sections */
     . = ALIGN(4);       /* long align for init.S copying */
     _postinit_end = .;
-  } > RAM
+  } >RAM
 
   .text ALIGN(4) :
   {
@@ -111,15 +112,17 @@ SECTIONS
     *(.text*)
     *(.rodata*)
     _code_end = .;
-  } > RAM
-  
-  .ctors ALIGN(4) : 
+  } >RAM
+
+  . = DATA_SEGMENT_ALIGN(CONSTANT(MAXPAGESIZE), CONSTANT(COMMONPAGESIZE));
+
+  .ctors ALIGN(4) :
   {
       _ctors = .;
       KEEP(*(.ctors))           /* Run in reverse order, so non-priority ones go first  */
       KEEP(*(SORT(.ctors.*)))   /* followed by ctors with priority */
       _ctors_end = .;
-  } > RAM
+  } >RAM
 
   .dtors ALIGN(4) : 
   {
@@ -127,7 +130,7 @@ SECTIONS
       KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first, highest to lowest */
       KEEP(*(.dtors))           /* Followed by non-priority ones */
       _dtors_end = .;
-  } > RAM
+  } >RAM
 
   .data ALIGN(4) :
   {
@@ -135,17 +138,18 @@ SECTIONS
     *(.data*)
     . = ALIGN(4);       /* long align for init.S copying */
     _data_end = .;
-  } > RAM
+  } >RAM
 
-  .bss(NOLOAD):
+  .bss ALIGN(4) :
   {
-    . = ALIGN(4);       /* Not strictly needed, but here in case we rearrange things */
     _bss_start = .;
     *(.bss*)
     *(COMMON)
     . = ALIGN(4);       /* long align for kinit clearing */
     _bss_end = .;
-  } > RAM
+  } >RAM
+
+  . = DATA_SEGMENT_END(.);
 
   _end = .;
 }

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -91,7 +91,7 @@ PROVIDE(_RUN_ADDRESS    = 0x00002000);  /* start of user memory         */
 
 SECTIONS
 {
-  .text.init :
+  .text.init _RUN_ADDRESS : AT(_LOAD_ADDRESS)
   {
     _init = .;
     KEEP(*(.init))      /* KEEP() "anchors" section for gc-sections */
@@ -127,7 +127,7 @@ SECTIONS
   .dtors ALIGN(4) : 
   {
       _dtors = .;
-      KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first, highest to lowest */
+      KEEP(*(SORT(.dtors.*)))   /* dtors with priority go first */
       KEEP(*(.dtors))           /* Followed by non-priority ones */
       _dtors_end = .;
   } >RAM

--- a/code/software/memcheck/funcs.asm
+++ b/code/software/memcheck/funcs.asm
@@ -105,7 +105,7 @@ RESTORE_BERR_HANDLER::
     move.l  SAVEDHANDLER,$8
     rts
 
-    section .data
+    section .data,data
     align   2
 SAVEDHANDLER    dc.l  0
 

--- a/code/software/software.mk
+++ b/code/software/software.mk
@@ -66,6 +66,23 @@ CFLAGS+=--param=min-pagesize=0
 endif
 endif
 
+# For systems without MMU support, aligning LOAD segments with pages is not needed
+# In those cases, provide fake page sizes to both save space and remove RWX warnings
+ifeq ($(CPU),68030)
+LD_LD_SUPPORT_MMU?=true
+endif
+ifeq ($(CPU),68040)
+LD_SUPPORT_MMU?=true
+endif
+ifeq ($(CPU),68060)
+LD_SUPPORT_MMU?=true
+endif
+LD_SUPPORT_MMU?=false
+ifneq ($(LD_SUPPORT_MMU),true)
+# Saves space in binaries, but will break MMU use
+LDFLAGS+=-z max-page-size=16 -z common-page-size=16
+endif
+
 # Output config (assume name of directory)
 PROGRAM_BASENAME=$(shell basename $(CURDIR))
 

--- a/code/software/tests/cpuinfo/kmain.asm
+++ b/code/software/tests/cpuinfo/kmain.asm
@@ -112,12 +112,12 @@ IIHANDLER:
     move.l  CONTADDR,(2,A7)           ; Update continue PC
     rte
 
-    section .rodata
+    section .rodata,text
 MODULE    dc.l    $0                  ; Option 0, Type 0, Rest ignored
           dc.l    MODENTRY            ; Entry word at MODENTRY
 SZCPU     dc.b    'MC680', 0
 
-    section .bss
+    section .bss,bss
 M16BUF    ds.l    4
 IISAVED   ds.l    1
 FLSAVED   ds.l    1

--- a/code/software/updateflash/Makefile
+++ b/code/software/updateflash/Makefile
@@ -12,8 +12,9 @@ else
 $(info NOTE: Using ROSCO_M68K_DIR libs in: $(ROSCO_M68K_DIR))
 endif
 
-ROM_OBJ=rosco_rom.o
+ROM_BIN?=
 ifneq ($(ROM_BIN),)
+ROM_OBJ=rosco_rom.o
 $(info NOTE: Embedding ROM firmware image in $(ELF) binary: $(ROM_BIN))
 
 # Having this define in EXTRA_CFLAGS is a hack around an issue with
@@ -23,13 +24,15 @@ $(info NOTE: Embedding ROM firmware image in $(ELF) binary: $(ROM_BIN))
 EXTRA_CFLAGS=-DFIRMWARE_EMBEDDED
 
 OBJECTS+=$(ROM_OBJ)
-endif
 TO_CLEAN+=rosco_rom.bin $(ROM_OBJ)
+endif
 
 -include $(ROSCO_M68K_DIR)/code/software/software.mk
 
 EXTRA_LIBS=-lsdfat -lsst_flash
 
+ifneq ($(ROM_BIN),)
 $(ROM_OBJ): $(ROM_BIN)
 	$(CP) $(ROM_BIN) rosco_rom.bin
 	$(OBJCOPY) -I binary -O elf32-m68k -B m68k:68000 rosco_rom.bin $@
+endif

--- a/code/software/updateflash/Makefile
+++ b/code/software/updateflash/Makefile
@@ -12,17 +12,23 @@ else
 $(info NOTE: Using ROSCO_M68K_DIR libs in: $(ROSCO_M68K_DIR))
 endif
 
--include $(ROSCO_M68K_DIR)/code/software/software.mk
-
-EXTRA_LIBS=-lsdfat -lsst_flash
-
 ROM_OBJ=rosco_rom.o
 ifneq ($(ROM_BIN),)
 $(info NOTE: Embedding ROM firmware image in $(ELF) binary: $(ROM_BIN))
-DEFINES+=-DFIRMWARE_EMBEDDED
+
+# Having this define in EXTRA_CFLAGS is a hack around an issue with
+# interplay between this Makefile and software.mk. It works, but 
+# there's probably a better way to fix it 😅
+#
+EXTRA_CFLAGS=-DFIRMWARE_EMBEDDED
+
 OBJECTS+=$(ROM_OBJ)
 endif
 TO_CLEAN+=rosco_rom.bin $(ROM_OBJ)
+
+-include $(ROSCO_M68K_DIR)/code/software/software.mk
+
+EXTRA_LIBS=-lsdfat -lsst_flash
 
 $(ROM_OBJ): $(ROM_BIN)
 	$(CP) $(ROM_BIN) rosco_rom.bin


### PR DESCRIPTION
I hit this error building develop rosco_m68k_firmware:

make[1]: *** No rule to make target `lzgmini_68k.o', needed by `rosco_m68k.elf'.  Stop.

Its seems a rule to make .o from .s (as well as .asm) was needed in firmware Makefile.  Works for me now.