### PR TITLE
Improve Updateflash ROM ID Error Message

### DIFF
--- a/code/software/updateflash/updateflash.c
+++ b/code/software/updateflash/updateflash.c
@@ -69,17 +69,17 @@ finally:
 static uint32_t get_logical_rom_size(SSTDeviceId *even, SSTDeviceId *odd) {
     uint32_t even_romsize = 0;
     if (even->manufacturer == SST_MFR_SST) {
-    switch (even->device) {
-    case SST_DEV_010A:
+        switch (even->device) {
+        case SST_DEV_010A:
             even_romsize = 262144;
-        break;
-    case SST_DEV_020A:
+            break;
+        case SST_DEV_020A:
             even_romsize = 524288;
-        break;
-    case SST_DEV_040:
+            break;
+        case SST_DEV_040:
             even_romsize = 1048576;
-        break;
-    }
+            break;
+        }
     }
 
     uint32_t odd_romsize = 0;
@@ -146,7 +146,8 @@ int main(int argc, char **argv) {
     uint32_t logical_romsize = get_logical_rom_size(&even, &odd);
 
     if (logical_romsize == 0) {
-        printf("Apologies, but ROMs don't appear to be SST flash, this utility cannot program them.\n");
+        printf("Apologies, but ROMs could not be identified, this utility cannot program them.\n");
+        printf("Please check that the flash write jumper (JP3) is installed and that the ROMs are SST flash.\n");
     } else {
         printf("\nLogical ROM size is %ld bytes\n", logical_romsize);
 #if defined(FIRMWARE_EMBEDDED)

--- a/code/software/updateflash/updateflash.c
+++ b/code/software/updateflash/updateflash.c
@@ -67,36 +67,37 @@ finally:
 }
 
 static uint32_t get_logical_rom_size(SSTDeviceId *even, SSTDeviceId *odd) {
-    uint32_t romsize = 0;
-
+    uint32_t even_romsize = 0;
+    if (even->manufacturer == SST_MFR_SST) {
     switch (even->device) {
     case SST_DEV_010A:
-        romsize = 262144;
+            even_romsize = 262144;
         break;
     case SST_DEV_020A:
-        romsize = 524288;
+            even_romsize = 524288;
         break;
     case SST_DEV_040:
-        romsize = 1048576;
+            even_romsize = 1048576;
         break;
     }
+    }
 
-    if (even->device != odd->device) {
-        switch(odd->device) {
+    uint32_t odd_romsize = 0;
+    if (odd->manufacturer == SST_MFR_SST) {
+        switch (odd->device) {
         case SST_DEV_010A:
-            romsize = 262144;
+            odd_romsize = 262144;
             break;
         case SST_DEV_020A:
-            if (romsize > 524288) {
-                romsize = 524288;
-            }
+            odd_romsize = 524288;
             break;
         case SST_DEV_040:
-            // Must already be smaller than this...
+            odd_romsize = 1048576;
             break;
         }
     }
 
+    uint32_t romsize = even_romsize < odd_romsize ? even_romsize : odd_romsize;
     return romsize;
 }
 


### PR DESCRIPTION
This fixes #361 by adding a mention of the write protect jumper when the ROM size cannot be determined.

It also adds a check for the device manufacturer before checking the device ID, to avoid misidentifying a device with the same ID but a different manufacturer, which could be of a different size.