### PR TITLE
Boot ELF Kernel from Storage

### DIFF
--- a/code/firmware/rosco_m68k_firmware/stage2/idehdd/load.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/idehdd/load.c
@@ -16,12 +16,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "ata.h"
+#include "load.h"
 #include "part.h"
 
 extern void mcPrint(char *str);
 extern void print_unsigned(uint32_t num, uint8_t base);
 extern bool ATA_support_check();
-extern bool load_kernel(PartHandle *part);
 
 static bool try_boot(uint8_t device_id) {
     ATADevice device;

--- a/code/firmware/rosco_m68k_firmware/stage2/load/include/elf.h
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/include/elf.h
@@ -1,0 +1,123 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+ *                     |_____|       firmware v2
+ * ------------------------------------------------------------
+ * Copyright (c)2020-2022 Thomas Jager
+ * See top-level LICENSE.md for licence information.
+ *
+ * Definitions for ELF file contents.
+ * Only contains the ELF Header and Program Header.
+ * 
+ * Structures, names, and values based on:
+ *   Tool Interface Standard (TIS)
+ *   Executable and Linking Format (ELF) Specification
+ *   Version 1.2
+ * ------------------------------------------------------------
+ */
+
+#ifndef __ROSCO_M68K_ELF_H
+#define __ROSCO_M68K_ELF_H
+
+#include <stdint.h>
+
+#pragma pack(push, 1)
+
+typedef uint32_t Elf32_Addr;
+typedef uint16_t Elf32_Half;
+typedef uint32_t Elf32_Off;
+typedef int32_t Elf32_Sword;
+typedef uint32_t Elf32_Word;
+
+// ELF Header
+
+#define EI_MAG0         0
+#define EI_MAG1         1
+#define EI_MAG2         2
+#define EI_MAG3         3
+#define EI_CLASS        4
+#define EI_DATA         5
+#define EI_VERSION      6
+#define EI_PAD          7
+#define EI_NIDENT       16
+
+#define ELFMAG0     0x7f
+#define ELFMAG1     'E'
+#define ELFMAG2     'L'
+#define ELFMAG3     'F'
+
+#define ELFCLASSNONE    0
+#define ELFCLASS32      1
+#define ELFCLASS64      2
+
+#define ELFDATANONE 0
+#define ELFDATA2LSB 1
+#define ELFDATA2MSB 2
+
+#define ET_NONE     0
+#define ET_REL      1
+#define ET_EXEC     2
+#define ET_DYN      3
+#define ET_CORE     4
+#define ET_LOPROC   0xff00
+#define ET_HIPROC   0xffff
+
+#define EM_NONE         0
+#define EM_M32          1
+#define EM_SPARC        2
+#define EM_386          3
+#define EM_68K          4
+#define EM_88K          5
+#define EM_860          7
+#define EM_MIPS         8
+#define EM_MIPS_RS4_BE  10
+
+#define EV_NONE     0
+#define EV_CURRENT  1
+
+typedef struct {
+    unsigned char   e_ident[EI_NIDENT];
+    Elf32_Half      e_type;
+    Elf32_Half      e_machine;
+    Elf32_Word      e_version;
+    Elf32_Addr      e_entry;
+    Elf32_Off       e_phoff;
+    Elf32_Off       e_shoff;
+    Elf32_Word      e_flags;
+    Elf32_Half      e_ehsize;
+    Elf32_Half      e_phentsize;
+    Elf32_Half      e_phnum;
+    Elf32_Half      e_shentsize;
+    Elf32_Half      e_shnum;
+    Elf32_Half      e_shstrndx;
+} Elf32_Ehdr;
+
+// Program Header
+
+#define PT_NULL     0
+#define PT_LOAD     1
+#define PT_DYNAMIC  2
+#define PT_INTERP   3
+#define PT_NOTE     4
+#define PT_SHLIB    5
+#define PT_PHDR     6
+#define PT_LOPROC   0x70000000
+#define PT_HIPROC   0x7fffffff
+
+typedef struct {
+    Elf32_Word  p_type;
+    Elf32_Off   p_offset;
+    Elf32_Addr  p_vaddr;
+    Elf32_Addr  p_paddr;
+    Elf32_Word  p_filesz;
+    Elf32_Word  p_memsz;
+    Elf32_Word  p_flags;
+    Elf32_Word  p_align;
+} Elf32_Phdr;
+
+#pragma pack(pop)
+
+#endif

--- a/code/firmware/rosco_m68k_firmware/stage2/load/include/elf.h
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/include/elf.h
@@ -24,8 +24,6 @@
 
 #include <stdint.h>
 
-#pragma pack(push, 1)
-
 typedef uint32_t Elf32_Addr;
 typedef uint16_t Elf32_Half;
 typedef uint32_t Elf32_Off;
@@ -93,7 +91,7 @@ typedef struct {
     Elf32_Half      e_shentsize;
     Elf32_Half      e_shnum;
     Elf32_Half      e_shstrndx;
-} Elf32_Ehdr;
+} __attribute__ ((packed)) Elf32_Ehdr;
 
 // Program Header
 
@@ -116,8 +114,6 @@ typedef struct {
     Elf32_Word  p_memsz;
     Elf32_Word  p_flags;
     Elf32_Word  p_align;
-} Elf32_Phdr;
-
-#pragma pack(pop)
+} __attribute__ ((packed)) Elf32_Phdr;
 
 #endif

--- a/code/firmware/rosco_m68k_firmware/stage2/load/include/fat_custom.h
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/include/fat_custom.h
@@ -31,5 +31,6 @@
 // Added by us
 #define FATFS_INC_LOCKING               0
 #define FATFS_INC_USELESS_STUFF         0
-#define FATFS_MINIMAL_API               1
+#define FATFS_MINIMAL_API               0
+#define FATFS_INC_WRITE_SUPPORT         0
 

--- a/code/firmware/rosco_m68k_firmware/stage2/load/include/fat_custom.h
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/include/fat_custom.h
@@ -32,5 +32,3 @@
 #define FATFS_INC_LOCKING               0
 #define FATFS_INC_USELESS_STUFF         0
 #define FATFS_MINIMAL_API               0
-#define FATFS_INC_WRITE_SUPPORT         0
-

--- a/code/firmware/rosco_m68k_firmware/stage2/load/include/load.h
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/include/load.h
@@ -1,0 +1,39 @@
+/*
+ *------------------------------------------------------------
+ *                                  ___ ___ _
+ *  ___ ___ ___ ___ ___       _____|  _| . | |_
+ * |  _| . |_ -|  _| . |     |     | . | . | '_|
+ * |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+ *                     |_____|       firmware v2
+ * ------------------------------------------------------------
+ * Copyright (c)2020-2023 Ross Bamford and contributors
+ * See top-level LICENSE.md for licence information.
+ *
+ * Interface for loading programs from storage
+ * ------------------------------------------------------------
+ */
+
+#ifndef __ROSCO_M68K_LOAD_H
+#define __ROSCO_M68K_LOAD_H
+
+#include <stdbool.h>
+#include "part.h"
+#include "system.h"
+
+/*
+ * This is what a Kernel entry point should look like.
+ */
+typedef void (*KMain)(volatile SystemDataBlock * const);
+
+bool load_kernel(PartHandle *part);
+
+#ifdef SDFAT_LOADER
+// This is provided by the SD/FAT loader
+extern bool sd_load_kernel();
+#endif
+#ifdef IDE_LOADER
+// This is provided by the IDE/FAT loader
+extern bool ide_load_kernel();
+#endif
+
+#endif  //__ROSCO_M68K_LOAD_H

--- a/code/firmware/rosco_m68k_firmware/stage2/load/load.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/load.c
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include "load.h"
 #include "elf.h"
 #include "fat_filelib.h"
 #include "part.h"
@@ -33,8 +34,6 @@
 
 extern void mcPrint(const char *str);
 extern void print_unsigned(uint32_t num, uint8_t base);
-
-typedef void (*KMain)(volatile SystemDataBlock * const);
 
 extern uint8_t *kernel_load_ptr;
 extern KMain kernel_entry;

--- a/code/firmware/rosco_m68k_firmware/stage2/load/load.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/load.c
@@ -27,7 +27,9 @@
  * If ELF_LOAD_VIRTUAL_ADDR is 1, instead load every segment to its run virtual
  * address, and use E_ENTRY.
  */ 
+#ifndef ELF_LOAD_VIRTUAL_ADDR
 #define ELF_LOAD_VIRTUAL_ADDR 0
+#endif
 
 extern void mcPrint(const char *str);
 extern void print_unsigned(uint32_t num, uint8_t base);
@@ -129,24 +131,22 @@ static bool load_range_allowed(uintptr_t start, size_t size) {
 }
 
 static long load_kernel_elf_phdr_load(void *file, Elf32_Phdr *phdr) {
+#if ELF_LOAD_VIRTUAL_ADDR
+    const Elf32_Addr load_addr = phdr->p_vaddr;
+#else
+    const Elf32_Addr load_addr = phdr->p_paddr;
+#endif
+
     // TODO: Validate other fields and don't allow overwriting kernel memory
     if (phdr->p_align > 0) {
-#if ELF_LOAD_VIRTUAL_ADDR
-        if (phdr->p_vaddr % phdr->p_align != phdr->p_offset % phdr->p_align) {
-#else
-        if (phdr->p_paddr % phdr->p_align != phdr->p_offset % phdr->p_align) {
-#endif
+        if (load_addr % phdr->p_align != phdr->p_offset % phdr->p_align) {
             mcPrint("\r\n*** Invalid loadable segment alignment\r\n");
             return -1;
         }
     }
 
     // Don't allow overwriting firmware-reserved areas, stage2, or stack
-#if ELF_LOAD_VIRTUAL_ADDR
-    if (!load_range_allowed(phdr->p_vaddr, phdr->p_memsz)) {
-#else
-    if (!load_range_allowed(phdr->p_paddr, phdr->p_memsz)) {
-#endif
+    if (!load_range_allowed(load_addr, phdr->p_memsz)) {
             mcPrint("\r\n*** Segment would overwrite firmware memory\r\n");
             return -1;
     }
@@ -162,11 +162,7 @@ static long load_kernel_elf_phdr_load(void *file, Elf32_Phdr *phdr) {
         size_t count_to_do = phdr->p_filesz - count_done;
         this_count = count_to_do > BYTES_PER_DOT ? BYTES_PER_DOT : count_to_do;
 
-#if ELF_LOAD_VIRTUAL_ADDR
-        if (fl_fread((void *) (phdr->p_vaddr + count_done), 1, this_count, file) != this_count) {
-#else
-        if (fl_fread((void *) (phdr->p_paddr + count_done), 1, this_count, file) != this_count) {
-#endif
+        if (fl_fread((void *) (load_addr + count_done), 1, this_count, file) != this_count) {
             mcPrint("\r\n*** Couldn't read loadable segment\r\n");
             return -1;
         }
@@ -175,11 +171,7 @@ static long load_kernel_elf_phdr_load(void *file, Elf32_Phdr *phdr) {
     }
 
     // Clear remaining bytes in segment memory image
-#if ELF_LOAD_VIRTUAL_ADDR
-    memset((void *) (phdr->p_vaddr + phdr->p_filesz), 0, phdr->p_memsz - phdr->p_filesz);
-#else
-    memset((void *) (phdr->p_paddr + phdr->p_filesz), 0, phdr->p_memsz - phdr->p_filesz);
-#endif
+    memset((void *) (load_addr + phdr->p_filesz), 0, phdr->p_memsz - phdr->p_filesz);
 
     return phdr->p_filesz;
 }

--- a/code/firmware/rosco_m68k_firmware/stage2/load/load.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/load.c
@@ -270,7 +270,10 @@ bool load_kernel_elf(void *file) {
     (void) load_paddr;  // Suppress unused variable
 #else
     // In physical load mode, the first load segment must physically be at kernel_entry (0x40000)
-    if (!have_load_paddr || load_paddr != (Elf32_Addr) kernel_entry) {
+    if (!have_load_paddr) {
+        mcPrint("\r\n*** ELF program has no segments to load\r\n");
+        return false;
+    } else if (load_paddr != (Elf32_Addr) kernel_entry) {
         mcPrint("\r\n*** ELF program load physical address is not at 0x");
         print_unsigned((uint32_t) kernel_entry, 16);
         mcPrint("\r\n");

--- a/code/firmware/rosco_m68k_firmware/stage2/main2.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/main2.c
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <stdnoreturn.h>
 #include <stdbool.h>
+#include "load.h"
 #include "machine.h"
 #include "system.h"
 #include "serial.h"
@@ -31,31 +32,17 @@ extern void red_led_off();
 extern void mcBusywait(uint32_t);
 #endif
 
-/*
- * This is what a Kernel entry point should look like.
- */
-typedef void (*KMain)(volatile SystemDataBlock * const);
-
 // Linker defines
 extern uint32_t _bss_start, _bss_end;
 static volatile SystemDataBlock * const sdb = (volatile SystemDataBlock * const)0x400;
 
-// Kernels are loaded at the same address regardless of _how_ they're loaded
+// Flat binary kernels are loaded at the same address regardless of _how_ they're loaded
 uint8_t *kernel_load_ptr = (uint8_t*) KERNEL_LOAD_ADDRESS;
 KMain kernel_entry = (KMain) KERNEL_LOAD_ADDRESS;
 
 #ifdef KERMIT_LOADER
 // This is provided by Kermit
 extern int receive_kernel();
-#endif
-
-#ifdef SDFAT_LOADER
-// This is provided by the SD/FAT loader
-extern bool sd_load_kernel();
-#endif
-#ifdef IDE_LOADER
-// This is provided by the IDE/FAT loader
-extern bool ide_load_kernel();
 #endif
 
 void linit() {

--- a/code/firmware/rosco_m68k_firmware/stage2/main2.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/main2.c
@@ -42,7 +42,7 @@ static volatile SystemDataBlock * const sdb = (volatile SystemDataBlock * const)
 
 // Kernels are loaded at the same address regardless of _how_ they're loaded
 uint8_t *kernel_load_ptr = (uint8_t*) KERNEL_LOAD_ADDRESS;
-static KMain kmain = (KMain) KERNEL_LOAD_ADDRESS;
+KMain kernel_entry = (KMain) KERNEL_LOAD_ADDRESS;
 
 #ifdef KERMIT_LOADER
 // This is provided by Kermit
@@ -114,7 +114,7 @@ have_kernel:
     red_led_off();
     mcPrint("\r\n");
 
-    kmain(sdb);
+    kernel_entry(sdb);
 
     mcPrint("\x1b[1;31mSEVERE\x1b: Kernel should not return! Halting\r\n");
 

--- a/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
+++ b/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
@@ -14,7 +14,7 @@ SECTIONS
     _kermit_start = .;
     *(.kermit)
     _kermit_end = .;
-    ASSERT(_kermit_end < 0x40000, "Error: No room left for kernel load region");
+    ASSERT(_kermit_end <= 0x40000, "Error: No room left for kernel load region");
   } > RAM
 
   .text stage2 :

--- a/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
+++ b/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
@@ -1,11 +1,12 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
 kermit_buffers = 0x2000;
-stage2 = 0xF0000;
 MEMORY
 {
   RAM : org = 0x00000, l = 0x100000
 }
+
+PROVIDE(STAGE2_LOAD     = 0x000F0000);
 
 SECTIONS
 {
@@ -17,7 +18,7 @@ SECTIONS
     ASSERT(_kermit_end <= 0x40000, "Error: No room left for kernel load region");
   } > RAM
 
-  .text stage2 :
+  .text STAGE2_LOAD :
   {
     _code = .;
     *(.text.init)

--- a/code/firmware/rosco_m68k_firmware/stage2/sdfat/load.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/sdfat/load.c
@@ -16,11 +16,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "bbsd.h"
+#include "load.h"
 #include "part.h"
 
 extern void mcPrint(const char *str);
 extern bool BBSD_support_check();
-extern bool load_kernel(PartHandle *part);
 
 bool sd_load_kernel() {
     if (!BBSD_support_check()) {

--- a/code/software/libs/src/start_serial/init.S
+++ b/code/software/libs/src/start_serial/init.S
@@ -31,10 +31,8 @@
 
 ; NOTE: Loaded at $00040000 but init code is position-independent.
 
-START::                           ; position-independent load addr
-    move.l  SDB_MEMSIZE,A7        ; Reset stack to top of memory
-
-    lea.l   START(PC),A0          ; PC-rel source addr (load addr)
+RELOC:                            ; position-independent load addr
+    lea.l   RELOC(PC),A0          ; PC-rel source addr (load addr)
     lea.l   _init,A1              ; absolute dest addr (run addr)
     move.l  #_postinit_end,D0     ; init section absolute end addr
     sub.l   A1,D0                 ; subtract dest addr for init length
@@ -62,7 +60,9 @@ POSTINIT:                         ; running from copied run addr location
     dbra    D0,.COPY_LOOP         ; inner loop
     dbra    D1,.COPY_LOOP         ; outer loop
 
-PREMAIN:
+_start::                          ; entrypoint at copied run addr location
+    move.l  SDB_MEMSIZE,A7        ; reset stack to top of memory
+
     ; Save existing program exit EFP
     ; Cannot use stack as we may jump directly with exit() or abort(),
     ; from arbitrarily nested code...

--- a/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/hugerom_rosco_m68k_program.ld
@@ -15,7 +15,7 @@
  */
 
 OUTPUT_FORMAT("binary")
-ENTRY(START)
+ENTRY(_start)
 
 MEMORY
 {

--- a/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
+++ b/code/software/libs/src/start_serial/link_scripts/rosco_m68k_program.ld
@@ -15,7 +15,7 @@
  */
 
 OUTPUT_FORMAT("binary")
-ENTRY(START)
+ENTRY(_start)
 
 MEMORY
 {


### PR DESCRIPTION
I've had this mostly completed but just sitting around for a while. I hadn't properly tested it, and found that it didn't work with programs that copy themselves to 0x2000 (I had been testing with Mosys, which just runs from 0x40000). I've fixed that issue, so I'm looking for some thoughts on it.
This now works with the ELF files that are generated during the compilation of the software.

This loader only handles executable ELF files (not relocatable or dynamic objects). This is done to keep it simple (this is an alternative to just copying the flat binary to memory), only reading loadable segments to the physical memory addresses specified, not processing sections at all.

For now, the ELF segments are loaded to the physical addresses (LMA in the linker) given for each one, and (the default) 0x40000 is kept as the address to run. Ideally, every segment would be loaded to its virtual address, and execution would start at the address given in E_ENTRY. Since stage2 is running from 0x2000, it conflicts with the virtual address (VMA in the linker) of typical programs. For now, the program init is responsible for moving the rest of the program to its run location, as with a normal flat binary program.
This is controlled by the ELF_LOAD_VIRTUAL_ADDR macro.

The linker script entry point for software is changed to be the first bit of code that doesn't copy the program to 0x2000. Currently this has no effect, but it will be meaningful if the program segments are loaded to the correct virtual addresses, in which case E_ENTRY will be used.

This requires using more than the minimal FATFS API, but this change by itself doesn't significantly increase code size.
For this PR, I'm looking for some comments on the approach. I'm not fully satisfied with it, but I think it may be harder to get where I'd like easily while stage2 gets decompressed to RAM, instead of running from flash.