### PR TITLE
Move Decompressed Stage2 to the Top of On-Board RAM

### DIFF
--- a/code/firmware/rosco_m68k_firmware/bootstrap.asm
+++ b/code/firmware/rosco_m68k_firmware/bootstrap.asm
@@ -20,7 +20,7 @@
     section .text
 
 VECTORS:
-    dc.l    RAMLIMIT                    ; 00: Stack (top of on-board RAM)
+    dc.l    STAGE2_LOAD                 ; 00: Stack (below stage2)
     dc.l    START                       ; 01: Initial PC (start of ROM code)
 
     dc.l    BUS_ERROR_HANDLER           ; 02: Bus Error

--- a/code/firmware/rosco_m68k_firmware/decompress.asm
+++ b/code/firmware/rosco_m68k_firmware/decompress.asm
@@ -2,11 +2,11 @@
 
 decompress_stage2::
     move.l  D2,-(A7)
-    movea.l 8(A7),A0      ; Source address
-    move.l  12(A7),D0     ; Source length
-    movea.l #$F0000,A1    ; Target address
-    move.l  #$10000,D1    ; Limit to the top of on-board memory
-    jsr     _LZG_Decode   ; Do the unzip
-    move    D2,D0         ; ... and return the size
+    movea.l 8(A7),A0            ; Source address
+    move.l  12(A7),D0           ; Source length
+    movea.l #STAGE2_LOAD,A1     ; Target address
+    move.l  #$10000,D1          ; Limit to the top of on-board memory
+    jsr     _LZG_Decode         ; Do the unzip
+    move    D2,D0               ; ... and return the size
     move.l  (A7)+,D2
     rts

--- a/code/firmware/rosco_m68k_firmware/decompress.asm
+++ b/code/firmware/rosco_m68k_firmware/decompress.asm
@@ -4,8 +4,8 @@ decompress_stage2::
     move.l  D2,-(A7)
     movea.l 8(A7),A0      ; Source address
     move.l  12(A7),D0     ; Source length
-    movea.l #$2000,A1     ; Target address
-    move.l  #$F0000,D1    ; Arbitrary artifical target limit...
+    movea.l #$F0000,A1    ; Target address
+    move.l  #$10000,D1    ; Limit to the top of on-board memory
     jsr     _LZG_Decode   ; Do the unzip
     move    D2,D0         ; ... and return the size
     move.l  (A7)+,D2

--- a/code/firmware/rosco_m68k_firmware/main1.c
+++ b/code/firmware/rosco_m68k_firmware/main1.c
@@ -68,8 +68,8 @@ static uint32_t * const mem_size_sdb_ptr = (uint32_t *)MEM_SIZE_SDB_ADDRESS;
 static uint32_t * const program_loader_ptr = (uint32_t *)PROGRAM_LOADER_EFP_ADDRESS;
 static uint32_t * const prog_exit_ptr = (uint32_t *)PROGRAM_EXIT_EFP_ADDRESS;
 
-// Stage 2 loads at 0x2000
-static Stage2 stage2 = (Stage2) 0x2000;
+// Stage 2 loads at 0xF0000
+static Stage2 stage2 = (Stage2) 0xF0000;
 
 noreturn void main1();
 

--- a/code/firmware/rosco_m68k_firmware/main1.c
+++ b/code/firmware/rosco_m68k_firmware/main1.c
@@ -69,7 +69,8 @@ static uint32_t * const program_loader_ptr = (uint32_t *)PROGRAM_LOADER_EFP_ADDR
 static uint32_t * const prog_exit_ptr = (uint32_t *)PROGRAM_EXIT_EFP_ADDRESS;
 
 // Stage 2 loads at 0xF0000
-static Stage2 stage2 = (Stage2) 0xF0000;
+extern void STAGE2_LOAD(void);
+static Stage2 stage2 = &STAGE2_LOAD;
 
 noreturn void main1();
 

--- a/code/firmware/rosco_m68k_firmware/rosco_m68k_firmware_1M.ld
+++ b/code/firmware/rosco_m68k_firmware/rosco_m68k_firmware_1M.ld
@@ -8,6 +8,8 @@ MEMORY
   ROM : org = phys, l = 1M
 }
 
+PROVIDE(STAGE2_LOAD     = 0x000F0000);
+
 /* minimal items for XANSI in C */
 PROVIDE(_EFP_RECVCHAR   = 0x00000434);  /* Receive a character via UART */
 PROVIDE(_EFP_CHECKCHAR  = 0x00000444);  /* Check char ready from UART   */

--- a/code/firmware/rosco_m68k_firmware/rosco_m68k_firmware_64k.ld
+++ b/code/firmware/rosco_m68k_firmware/rosco_m68k_firmware_64k.ld
@@ -8,6 +8,8 @@ MEMORY
   ROM : org = phys, l = 64K
 }
 
+PROVIDE(STAGE2_LOAD     = 0x000F0000);
+
 /* minimal items for XANSI in C */
 PROVIDE(_EFP_RECVCHAR   = 0x00000434);  /* Receive a character via UART */
 PROVIDE(_EFP_CHECKCHAR  = 0x00000444);  /* Check char ready from UART   */

--- a/code/firmware/rosco_m68k_firmware/stage2/init2.asm
+++ b/code/firmware/rosco_m68k_firmware/stage2/init2.asm
@@ -14,10 +14,9 @@
     include "../rosco_m68k_private.asm"
 
     section .text.init
-    org     $2000
 
 START::
-    move.l  SDB_MEMSIZE,A7              ; Stack to top of RAM
+    movea.l #START,A7                   ; Stack to just below this code
     lea.l   linit,A0
     jsr     (A0)
     lea.l   lmain,A0

--- a/code/firmware/rosco_m68k_firmware/stage2/init2.asm
+++ b/code/firmware/rosco_m68k_firmware/stage2/init2.asm
@@ -16,7 +16,7 @@
     section .text.init
 
 START::
-    movea.l #START,A7                   ; Stack to just below this code
+    movea.l VECTORS_LOAD,A7             ; Stack to the default stack pointer vector
     lea.l   linit,A0
     jsr     (A0)
     lea.l   lmain,A0

--- a/code/firmware/rosco_m68k_firmware/stage2/kermit/kermit_support.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/kermit/kermit_support.c
@@ -22,11 +22,12 @@
 extern void mcPrint(char *str);
 extern void mcBusywait(uint32_t nops);
 
-UCHAR o_buf[OBUFLEN+8];         /* File output buffer */
-UCHAR i_buf[IBUFLEN+8];         /* File input buffer */
+/* Large kermit structures are kept in free memory 0x02000-0x40000 */
+UCHAR o_buf[OBUFLEN+8] __attribute__ ((section (".kermit")));   /* File output buffer */
+UCHAR i_buf[IBUFLEN+8] __attribute__ ((section (".kermit")));   /* File input buffer */
 
-static struct k_data k;
-static struct k_response response;
+static struct k_data k __attribute__ ((section ( ".kermit")));
+static struct k_response response __attribute__ ((section (".kermit")));
 
 extern uint8_t *kernel_load_ptr;
 static uint8_t *current_load_ptr;

--- a/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
+++ b/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
@@ -1,14 +1,14 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
-phys = 0x2000;
+stage2 = 0xF0000;
 MEMORY
 {
-  RAM : org = phys, l = 0xFDFFF   /* Allow loader to use all of RAM */
+  RAM : org = 0x00000, l = 0x100000
 }
 
 SECTIONS
 {
-  .text : AT(0)
+  .text stage2 :
   {
     _code = .;
     *(.text.init)
@@ -18,14 +18,14 @@ SECTIONS
     _code_end = .;
   } > RAM
 
-  .data : ALIGN(2) 
+  .data ALIGN(4) :
   {
     _data_start = .;
     *(.data*)
     _data_end = .;
   } > RAM
   
-  .bss : ALIGN(2)
+  .bss ALIGN(4) :
   {
     _bss_start = .;
     *(COMMON)

--- a/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
+++ b/code/firmware/rosco_m68k_firmware/stage2/rosco_m68k_stage2.ld
@@ -1,5 +1,6 @@
 OUTPUT_FORMAT("binary")
 ENTRY(START)
+kermit_buffers = 0x2000;
 stage2 = 0xF0000;
 MEMORY
 {
@@ -8,6 +9,14 @@ MEMORY
 
 SECTIONS
 {
+  .kermit kermit_buffers (NOLOAD) :
+  {
+    _kermit_start = .;
+    *(.kermit)
+    _kermit_end = .;
+    ASSERT(_kermit_end < 0x40000, "Error: No room left for kernel load region");
+  } > RAM
+
   .text stage2 :
   {
     _code = .;


### PR DESCRIPTION
Pending any issues that are raised with doing it, this PR moves the decompressed stage2 firmware from 0x2000 to 0xF0000. The stack pointer (in firmware) is adjusted to start below that point instead of at the top of on-board memory.

Software `start_serial` is unchanged, and will still reset the stack pointer to the value at `SDB_MEMSIZE`.

Since kermit requires large buffers, these are placed starting at 0x2000. Since kermit-received files always go to 0x40000, this keeps the buffers out of the way, but allows this memory to be used for other purposes when kermit isn't active (e.g. ELF segments loaded there).