### PR TITLE
Feature/68000 probe support

### DIFF
--- a/code/firmware/rosco_m68k_firmware/Makefile
+++ b/code/firmware/rosco_m68k_firmware/Makefile
@@ -3,7 +3,7 @@
 # Copyright (c)2019-2022 Ross Bamford
 # See LICENSE
 
-CPU?=68010
+CPU?=68000
 ARCH?=$(CPU)
 TUNE?=$(CPU)
 EXTRA_CFLAGS?=-g
@@ -61,6 +61,7 @@ OBJECTS=bootstrap.o mfp.o duart.o rev1.o rev2.o lzgmini_68k.o	\
 WITH_BLOCKDEV?=true
 WITH_KERMIT?=true
 WITH_DEBUG_STUB?=true
+WITH_ATA?=true
 
 all: $(BINARY_EVEN) $(BINARY_ODD)
 
@@ -137,9 +138,14 @@ endif
 ifneq ($(WITH_BLOCKDEV),false)
 $(info === Building rosco_m68k firmware with block device support)
 include blockdev/include.mk
+ifeq ($(WITH_ATA),true)
+$(info === Building rosco_m68k firmware with ATA support)
 ifeq ($(ATA_DEBUG),true)
 $(info === Building rosco_m68k firmware with ATA_DEBUG IDE)
 DEFINES:=$(DEFINES) -DATA_DEBUG
+endif
+else
+$(info === Building rosco_m68k firmware without ATA support)
 endif
 endif
 
@@ -161,6 +167,7 @@ endif
 
 include easy68k/include.mk
 
+export WITH_ATA
 export ATA_DEBUG
 export WITH_BLOCKDEV
 export WITH_KERMIT

--- a/code/firmware/rosco_m68k_firmware/blockdev/ata.c
+++ b/code/firmware/rosco_m68k_firmware/blockdev/ata.c
@@ -318,15 +318,10 @@ static void ata_probe() {
 
 static uint8_t *berr_flag = (uint8_t*)BERR_FLAG;
 
+void TRY_DISABLE_ATA_INTERRUPT(volatile uint16_t *idereg);
+
 void ata_init() {
-    INSTALL_TEMP_BERR_HANDLER_C(&&post_write);      // Yes, this is a GCC extension.
-                                                    // No, I do not care. :D
-
-    // Disable interrupt
-    idereg[ATA_REG_WR_DEVICE_CONTROL] = 0x0002;
-
-post_write:
-    RESTORE_BERR_HANDLER();
+    TRY_DISABLE_ATA_INTERRUPT(idereg);
 
     FW_PRINT_C("Initializing hard drives... ");
 

--- a/code/firmware/rosco_m68k_firmware/blockdev/ata.c
+++ b/code/firmware/rosco_m68k_firmware/blockdev/ata.c
@@ -316,16 +316,16 @@ static void ata_probe() {
 // This means ata_init **must** be called before any video devices are
 // initialized!
 
-extern void INSTALL_TEMP_BERR_HANDLER(void);
-extern void RESTORE_BERR_HANDLER(void);
 static uint8_t *berr_flag = (uint8_t*)BERR_FLAG;
 
 void ata_init() {
-    INSTALL_TEMP_BERR_HANDLER();
+    INSTALL_TEMP_BERR_HANDLER_C(&&post_write);      // Yes, this is a GCC extension.
+                                                    // No, I do not care. :D
 
     // Disable interrupt
     idereg[ATA_REG_WR_DEVICE_CONTROL] = 0x0002;
 
+post_write:
     RESTORE_BERR_HANDLER();
 
     FW_PRINT_C("Initializing hard drives... ");

--- a/code/firmware/rosco_m68k_firmware/blockdev/ata_disable_interrupt.asm
+++ b/code/firmware/rosco_m68k_firmware/blockdev/ata_disable_interrupt.asm
@@ -1,0 +1,35 @@
+;
+;------------------------------------------------------------
+;                                  ___ ___ _
+;  ___ ___ ___ ___ ___       _____|  _| . | |_
+; |  _| . |_ -|  _| . |     |     | . | . | '_|
+; |_| |___|___|___|___|_____|_|_|_|___|___|_,_|
+;                     |_____|
+; ------------------------------------------------------------
+; Copyright (c) 2023 Ross Bamford & Contributors
+; MIT License
+;
+; ASM interrupt disable with bus error check for probing
+; ------------------------------------------------------------
+
+ATA_REG_WR_DEVICE_CTL   equ     28
+
+; Try to disable the ATA interrupt.
+;
+; Will set BERR_FLAG if no ATA device is installed.
+;
+TRY_DISABLE_ATA_INTERRUPT::
+    move.l  A0,-(A7)                            ; Save regs
+    move.l  8(A7),A0                            ; Get argument pointer
+
+    jsr     INSTALL_TEMP_BERR_HANDLER           ; Install temp bus error handler
+    move.l  #.POST_WRITE,BERR_CONT_ADDR         ; Set up continue addr for 68000
+
+    move.w  #$0002,ATA_REG_WR_DEVICE_CTL(A0)    ; Try to disable IDE interrupt
+
+.POST_WRITE:
+    jsr     RESTORE_BERR_HANDLER                ; Restore the bus error handler
+    move.l  (A7)+,A0                            ; Restore regs
+    rts
+
+

--- a/code/firmware/rosco_m68k_firmware/blockdev/include.mk
+++ b/code/firmware/rosco_m68k_firmware/blockdev/include.mk
@@ -10,7 +10,7 @@ EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DROSCO_M68K_SDCARD -DSD_BLOCK_READ_ONLY -DBLOCK
 
 ifneq ($(HUGEROM),false)
 ifeq ($(WITH_ATA),true)
-OBJECTS := $(OBJECTS) blockdev/ata.o
+OBJECTS := $(OBJECTS) blockdev/ata_disable_interrupt.o blockdev/ata.o
 EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DROSCO_M68K_ATA
 endif
 

--- a/code/firmware/rosco_m68k_firmware/blockdev/include.mk
+++ b/code/firmware/rosco_m68k_firmware/blockdev/include.mk
@@ -1,16 +1,21 @@
 ifeq ($(REVISION1X),true)
-OBJECTS := $(OBJECTS) blockdev/mfp_gpio.o blockdev/bbspi.o blockdev/bbsd.o                  \
-						blockdev/syscalls_asm.o blockdev/ata.o
+OBJECTS := $(OBJECTS) blockdev/mfp_gpio.o blockdev/bbspi.o blockdev/bbsd.o                  	\
+						blockdev/syscalls_asm.o
 else
-OBJECTS := $(OBJECTS) blockdev/bbspi.o blockdev/bbsd.o blockdev/dua_spi_asm.o              \
-						blockdev/syscalls_asm.o blockdev/ata.o
+OBJECTS := $(OBJECTS) blockdev/bbspi.o blockdev/bbsd.o blockdev/dua_spi_asm.o              		\
+						blockdev/syscalls_asm.o
 endif
-EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DROSCO_M68K_SDCARD -DSD_BLOCK_READ_ONLY -DBLOCKDEV_SUPPORT \
-								-DROSCO_M68K_ATA -Iblockdev/include
+EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DROSCO_M68K_SDCARD -DSD_BLOCK_READ_ONLY -DBLOCKDEV_SUPPORT 	\
+				-Iblockdev/include
 
-ifeq ($(HUGEROM),true)
-BD_CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Wpedantic -Werror   \
-          -Iinclude -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE) -O3         \
+ifneq ($(HUGEROM),false)
+ifeq ($(WITH_ATA),true)
+OBJECTS := $(OBJECTS) blockdev/ata.o
+EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DROSCO_M68K_ATA
+endif
+
+BD_CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Werror   			\
+          -Iinclude -mcpu=$(CPU) -march=$(ARCH) -mtune=$(TUNE) -O3			\
           -fomit-frame-pointer $(DEFINES)
 
 blockdev/mfp_gpio.o: blockdev/mfp_gpio.c
@@ -22,7 +27,9 @@ blockdev/bbspi.o: blockdev/bbspi.c
 blockdev/bbsd.o: blockdev/bbsd.c
 	$(CC) -c $(BD_CFLAGS) $(EXTRA_CFLAGS) -o $@ $<
 
+ifeq ($(WITH_ATA),true)
 blockdev/ata.o: blockdev/ata.c
 	$(CC) -c $(BD_CFLAGS) $(EXTRA_CFLAGS) -o $@ $<
+endif
 endif
 

--- a/code/firmware/rosco_m68k_firmware/blockdev/syscalls_asm.asm
+++ b/code/firmware/rosco_m68k_firmware/blockdev/syscalls_asm.asm
@@ -332,10 +332,14 @@ SPI_BUFFER_OP:
 ;  A0   - Modified arbitrarily
 ;  A1   - May be modified arbitrarily
 FW_ATA_INIT:
+    ifd ROSCO_M68K_ATA
     move.l  A1,-(A7)
     move.l  D1,-(A7)
     jsr     ATA_init
     add.l   #8,A7
+    else
+    move.l  #1,D0       ; failure: no device
+    endif
     rts
 
 ; Arguments:
@@ -353,6 +357,7 @@ FW_ATA_INIT:
 ;  A1    - May be modified arbitrarily
 ;  A2    - May be modified arbitrarily
 FW_ATA_READ:
+    ifd ROSCO_M68K_ATA
     move.l  #ATA_read_sectors,A0
 
 ATA_XFER_OP:
@@ -362,6 +367,9 @@ ATA_XFER_OP:
     move.l  A2,-(A7)
     jsr     (A0)
     add.l   #16,A7
+    else
+    clr.l   d0
+    endif
     rts
 
 ; Arguments:
@@ -379,8 +387,12 @@ ATA_XFER_OP:
 ;  A1    - May be modified arbitrarily
 ;  A2    - May be modified arbitrarily
 FW_ATA_WRITE:
+    ifd ROSCO_M68K_ATA
     move.l  #ATA_write_sectors,A0
     bra.s   ATA_XFER_OP
+    else
+    clr.l   d0
+    endif
 
 ; Arguments:
 ;
@@ -396,10 +408,14 @@ FW_ATA_WRITE:
 ;  A1   - May be modified arbitrarily
 ;  A2   - May be modified arbitrarily
 FW_ATA_IDENT:
+    ifd ROSCO_M68K_ATA
     move.l  A1,-(A7)
     move.l  A2,-(A7)
     jsr     ATA_ident
     add.l   #8,A7
+    else
+    clr.l   d0
+    endif
     rts
 
 * ************************************************************************** *

--- a/code/firmware/rosco_m68k_firmware/bootstrap.asm
+++ b/code/firmware/rosco_m68k_firmware/bootstrap.asm
@@ -334,11 +334,6 @@ INSTALL_TEMP_BERR_HANDLER::
     move.l  #BERR_HANDLER,$8            ; Install temporary bus error handler
     rts
 
-; Convenience to install temporary BERR handler from C
-; Does all of the above, plus sets up the 68000 return address
-INSTALL_TEMP_BERR_HANDLER_C::
-    move.l  4(A7),BERR_CONT_ADDR        ; Move the function argument to BERR_CONT_ADDR
-    bra     INSTALL_TEMP_BERR_HANDLER
 
 ; Convenience to restore BERR handler from C, after a
 ; call to INSTALL_TEM_BERR_HANDLER.

--- a/code/firmware/rosco_m68k_firmware/bootstrap.asm
+++ b/code/firmware/rosco_m68k_firmware/bootstrap.asm
@@ -253,12 +253,14 @@ INITMEMCOUNT:
 
     move.b  #0,BERR_FLAG                ; Zero bus error flag
     move.l  $8,BERR_SAVED               ; Save the original bus error handler
+    move.l  #.POST_TEST,SDB_STATUS
     move.l  #BERR_HANDLER,$8            ; Install temporary bus error handler
     move.l  #.BLOCKSIZE,A0
 .LOOP
     move.l  #.TESTVALUE,(A0)
     move.l  (A0),D0
 
+.POST_TEST:
     tst.b   BERR_FLAG                   ; Was there a bus error?
     bne.s   .DONE                       ; Fail fast if so...
 
@@ -277,7 +279,11 @@ INITMEMCOUNT:
     rts
 
 
-; Temporary bus error handler
+; Temporary bus error handler;
+;
+; Requires a return address be placed in SDB_STATUS for the case
+; where the CPU is a 68000 (which cannot return from bus errors).
+;
 BERR_HANDLER::
     move.l  D0,-(A7)
     move.w  ($A,A7),D0                  ; Get format
@@ -301,9 +307,12 @@ BERR_HANDLER::
     beq.w   .IS020 
 
     ; If we're here, assume it's a 68000.
-    ; We can't return from a bus error, signal error.
+    ; Set up the stack with the supplied return address for rte
+    move.b  #1,BERR_FLAG
     move.l  (A7)+,D0
-    jmp     BUS_ERROR_HANDLER
+    addq.l  #8,A7
+    move.l  SDB_STATUS,2(A7)
+    rte
 
 .IS020
     move.w  ($E,A7),D0                  ; If we're here, it's an 020 frame...                
@@ -316,7 +325,7 @@ BERR_HANDLER::
     rte
 
 
-; Convenience to install temporary BERR handler from C
+; Convenience to install temporary BERR handler
 ; Zeroes bus error flag (at BERR_FLAG) and stores old handler
 ; for a subsequent RESTORE_BERR_HANDLER.
 INSTALL_TEMP_BERR_HANDLER::
@@ -326,6 +335,11 @@ INSTALL_TEMP_BERR_HANDLER::
     move.l  #BERR_HANDLER,$8            ; Install temporary bus error handler
     rts
 
+; Convenience to install temporary BERR handler from C
+; Does all of the above, plus sets up the 68000 return address
+INSTALL_TEMP_BERR_HANDLER_C::
+    move.l  4(A7),SDB_STATUS            ; Move the function argument to SDB_STATUS
+    bra     INSTALL_TEMP_BERR_HANDLER
 
 ; Convenience to restore BERR handler from C, after a
 ; call to INSTALL_TEM_BERR_HANDLER.

--- a/code/firmware/rosco_m68k_firmware/duart.asm
+++ b/code/firmware/rosco_m68k_firmware/duart.asm
@@ -161,9 +161,9 @@ INITDUART_ATBASE:
     ; for this on the first access, and if we get one, just bail immediately.
     move.b  #0,BERR_FLAG              ; Zero bus error flag
 
-    move.l  $8,BERR_SAVED             ; Save the original bus error handler
-    move.l  #.POST_WRITE,SDB_STATUS   ; In case we're on 68000, give a return address...
-    move.l  #BERR_HANDLER,$8          ; Install temporary bus error handler
+    move.l  $8,BERR_SAVED                   ; Save the original bus error handler
+    move.l  #.POST_WRITE,BERR_CONT_ADDR     ; In case we're on 68000, give a return address...
+    move.l  #BERR_HANDLER,$8                ; Install temporary bus error handler
 
     move.b  #$0,DUART_IMR(A0)         ; Mask all interrupts
 

--- a/code/firmware/rosco_m68k_firmware/duart.asm
+++ b/code/firmware/rosco_m68k_firmware/duart.asm
@@ -162,6 +162,7 @@ INITDUART_ATBASE:
     move.b  #0,BERR_FLAG              ; Zero bus error flag
 
     move.l  $8,BERR_SAVED             ; Save the original bus error handler
+    move.l  #.POST_WRITE,SDB_STATUS   ; In case we're on 68000, give a return address...
     move.l  #BERR_HANDLER,$8          ; Install temporary bus error handler
 
     move.b  #$0,DUART_IMR(A0)         ; Mask all interrupts
@@ -189,6 +190,7 @@ INITDUART_ATBASE:
     cmp.b   #$50,D0                   ; to 0x50.
     bne.s   .DONE                     ; If not as expected, no DUART...
 
+.POST_WRITE:
     ; If any of that generated a bus error, then it doesn't appear to be a 68681...
     tst.b   BERR_FLAG                 ; Was there a bus error?
     bne.s   .DONE                     ; Bail now if so...

--- a/code/firmware/rosco_m68k_firmware/duart.asm
+++ b/code/firmware/rosco_m68k_firmware/duart.asm
@@ -159,11 +159,8 @@ INITDUART_ATBASE:
 
     ; On r1.2, not having a 68681 will generate a bus error. We can look
     ; for this on the first access, and if we get one, just bail immediately.
-    move.b  #0,BERR_FLAG              ; Zero bus error flag
-
-    move.l  $8,BERR_SAVED                   ; Save the original bus error handler
+    jsr     INSTALL_TEMP_BERR_HANDLER       ; Install temporary bus error handler
     move.l  #.POST_WRITE,BERR_CONT_ADDR     ; In case we're on 68000, give a return address...
-    move.l  #BERR_HANDLER,$8                ; Install temporary bus error handler
 
     move.b  #$0,DUART_IMR(A0)         ; Mask all interrupts
 

--- a/code/firmware/rosco_m68k_firmware/include/machine.h
+++ b/code/firmware/rosco_m68k_firmware/include/machine.h
@@ -196,6 +196,8 @@ void FW_PRINTLN_C(char *str);
  */
 void BUSYWAIT_C(uint32_t ticks);
 
+typedef void (*voidfunc)(void);
+
 /*
  * Install temporary bus error handler that will set a flag if an error
  * occurs, and not retry the instruction.
@@ -206,8 +208,17 @@ void BUSYWAIT_C(uint32_t ticks);
  *
  * The flag will be set at BERR_FLAG (defined above). The flag will
  * be zeroed when this function is called.
+ * 
+ * You must provide a return address to be used in case the CPU is a
+ * 68000 - this will typically be the instruction after the faulting 
+ * one, and will not be used on 68010 or above.
+ * 
+ * This **must** only be used during early initialization, it is not
+ * reentrant and it (ab)uses the SDB_STATUS for temporary storage.
+ * 
+ * Do not leak pointers to this into stage 2 or user code!
  */
-extern void INSTALL_TEMP_BERR_HANDLER(void);
+extern void INSTALL_TEMP_BERR_HANDLER_C(voidfunc return68k);
 
 /*
  * Restore original bus error handler, saved by a prior call to

--- a/code/firmware/rosco_m68k_firmware/include/machine.h
+++ b/code/firmware/rosco_m68k_firmware/include/machine.h
@@ -196,36 +196,5 @@ void FW_PRINTLN_C(char *str);
  */
 void BUSYWAIT_C(uint32_t ticks);
 
-typedef void (*voidfunc)(void);
-
-/*
- * Install temporary bus error handler that will set a flag if an error
- * occurs, and not retry the instruction.
- *
- * Saves the existing handler for use by a subsequent RESTORE_BERR_HANDLER.
- *
- * Supports various m68k models.
- *
- * The flag will be set at BERR_FLAG (defined above). The flag will
- * be zeroed when this function is called.
- * 
- * You must provide a return address to be used in case the CPU is a
- * 68000 - this will typically be the instruction after the faulting 
- * one, and will not be used on 68010 or above.
- * 
- * This **must** only be used during early initialization, it is not
- * reentrant and it (ab)uses the SDB_STATUS for temporary storage.
- * 
- * Do not leak pointers to this into stage 2 or user code!
- */
-extern void INSTALL_TEMP_BERR_HANDLER_C(voidfunc return68k);
-
-/*
- * Restore original bus error handler, saved by a prior call to
- * INSTALL_TEMP_BERR_HANDLER.
- */
-extern void RESTORE_BERR_HANDLER(void);
-
-
 #endif
 

--- a/code/firmware/rosco_m68k_firmware/main1.c
+++ b/code/firmware/rosco_m68k_firmware/main1.c
@@ -236,10 +236,6 @@ if (!have_video) {
     INSTALL_BLOCKDEV_HANDLERS();
 #endif
 
-    // Reset the SDB_STATUS, since we (ab)use it for various things during hardware init...
-    uint32_t *sdb_status = (uint32_t*)0x404;
-    *sdb_status = 0xC001C001;
-
 #ifdef HAVE_DEBUG_STUB
     debug_stub();
 #endif

--- a/code/firmware/rosco_m68k_firmware/main1.c
+++ b/code/firmware/rosco_m68k_firmware/main1.c
@@ -230,9 +230,15 @@ if (!have_video) {
     print_cpu_mem_info();
 
 #ifdef BLOCKDEV_SUPPORT
+#ifdef ROSCO_M68K_ATA
     ata_init();
+#endif
     INSTALL_BLOCKDEV_HANDLERS();
 #endif
+
+    // Reset the SDB_STATUS, since we (ab)use it for various things during hardware init...
+    uint32_t *sdb_status = (uint32_t*)0x404;
+    *sdb_status = 0xC001C001;
 
 #ifdef HAVE_DEBUG_STUB
     debug_stub();

--- a/code/firmware/rosco_m68k_firmware/stage2/Makefile
+++ b/code/firmware/rosco_m68k_firmware/stage2/Makefile
@@ -51,8 +51,11 @@ LZG?=$(LZG_SRC)/tools/lzg
 
 OBJECTS=init2.o common.o serial.o machine.o main2.o
 
+ifeq ($(WITH_ATA), true)
+DEFINES:=$(DEFINES) -DROSCO_M68K_ATA
 ifeq ($(ATA_DEBUG),true)
 DEFINES:=$(DEFINES) -DATA_DEBUG
+endif
 endif
 ifeq ($(WITH_KERMIT),true)
 include kermit/include.mk
@@ -61,7 +64,9 @@ ifeq ($(WITH_BLOCKDEV),true)
 include load/include.mk
 include part/include.mk
 include sdfat/include.mk
+ifeq ($(WITH_ATA), true)
 include idehdd/include.mk
+endif
 endif
 ifeq ($(REVISION1X),true)
 DEFINES:=$(DEFINES) -DREVISION1X

--- a/code/firmware/rosco_m68k_firmware/stage2/idehdd/include.mk
+++ b/code/firmware/rosco_m68k_firmware/stage2/idehdd/include.mk
@@ -1,2 +1,2 @@
 OBJECTS := $(OBJECTS) idehdd/ata.o idehdd/load.o
-EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DIDE_LOADER -Iidehdd/include -I../blockdev/include
+EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DIDE_LOADER -Iidehdd/include

--- a/code/firmware/rosco_m68k_firmware/stage2/load/include.mk
+++ b/code/firmware/rosco_m68k_firmware/stage2/load/include.mk
@@ -4,4 +4,4 @@ OBJECTS := $(OBJECTS) load/load.o																						\
 	load/fat_io_lib/fat_misc.o load/fat_io_lib/fat_string.o										\
 	load/fat_io_lib/fat_table.o load/fat_io_lib/fat_write.o
 
-EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DFATFS_USE_CUSTOM_OPTS_FILE -Iload/include
+EXTRA_CFLAGS := $(EXTRA_CFLAGS) -DFATFS_USE_CUSTOM_OPTS_FILE -Iload/include -I../blockdev/include

--- a/code/firmware/rosco_m68k_firmware/stage2/part/include/part.h
+++ b/code/firmware/rosco_m68k_firmware/stage2/part/include/part.h
@@ -19,7 +19,11 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+
+#ifdef ROSCO_M68K_ATA
 #include "ata.h"
+#endif
+
 #include "bbsd.h"
 #include "part_mbr.h"
 
@@ -38,20 +42,26 @@ typedef struct {
 } RuntimePart;
 
 typedef enum {
+#ifdef ROSCO_M68K_ATA
     PART_DEVICE_TYPE_ATA,
+#endif
     PART_DEVICE_TYPE_BBSD,
 } PartDeviceType;
 
 typedef struct {
     PartDeviceType device_type;
     union {
+#ifdef ROSCO_M68K_ATA
         ATADevice   *ata_device;
+#endif
         BBSDCard    *bbsd_device;
     };
     RuntimePart parts[4];
 } PartHandle;
 
+#ifdef ROSCO_M68K_ATA
 PartInitStatus Part_init_ATA(PartHandle *handle, ATADevice *device);
+#endif
 PartInitStatus Part_init_BBSD(PartHandle *handle, BBSDCard *device);
 uint32_t Part_read(PartHandle *handle, uint8_t part_num, uint8_t *buffer, uint32_t start, uint32_t count);
 bool Part_valid(PartHandle *handle, uint8_t part);

--- a/code/firmware/rosco_m68k_firmware/stage2/part/part.c
+++ b/code/firmware/rosco_m68k_firmware/stage2/part/part.c
@@ -23,11 +23,14 @@
 
 static MBR buffer;
 
+#ifdef ROSCO_M68K_ATA
 #ifdef ATA_DEBUG
 extern void mcPrint(char *str);
 extern void print_unsigned(uint32_t num, uint8_t base);
 #endif
+#endif
 
+#ifdef ROSCO_M68K_ATA
 PartInitStatus Part_init_ATA(PartHandle *handle, ATADevice *device) {
 #ifdef ATA_DEBUG
     mcPrint("S2: Reading ");
@@ -63,6 +66,7 @@ PartInitStatus Part_init_ATA(PartHandle *handle, ATADevice *device) {
         return PART_INIT_READ_FAILURE;
     }
 }
+#endif
 
 PartInitStatus Part_init_BBSD(PartHandle *handle, BBSDCard *device) {
     if (BBSD_read_block(device, 0, (uint8_t*)&buffer)) {
@@ -86,6 +90,7 @@ PartInitStatus Part_init_BBSD(PartHandle *handle, BBSDCard *device) {
     }
 }
 
+#ifdef ROSCO_M68K_ATA
 static uint32_t Part_read_ATA(PartHandle *handle, uint8_t part_num, uint8_t *buffer, uint32_t start, uint32_t count) {
     if (part_num > 3 || handle->parts[part_num].type == 0) {
         return 0;
@@ -131,6 +136,7 @@ static uint32_t Part_read_ATA(PartHandle *handle, uint8_t part_num, uint8_t *buf
         }
     }
 }
+#endif
 
 static uint32_t Part_read_BBSD(PartHandle *handle, uint8_t part_num, uint8_t *buffer, uint32_t start, uint32_t count) {
     if (part_num > 3 || handle->parts[part_num].type == 0) {
@@ -159,8 +165,10 @@ static uint32_t Part_read_BBSD(PartHandle *handle, uint8_t part_num, uint8_t *bu
 
 uint32_t Part_read(PartHandle *handle, uint8_t part_num, uint8_t *buffer, uint32_t start, uint32_t count) {
     switch (handle->device_type) {
+#ifdef ROSCO_M68K_ATA
     case PART_DEVICE_TYPE_ATA:
         return Part_read_ATA(handle, part_num, buffer, start, count);
+#endif
     case PART_DEVICE_TYPE_BBSD:
         return Part_read_BBSD(handle, part_num, buffer, start, count);
     default:

--- a/code/firmware/rosco_m68k_firmware/video9958/vdpcon.asm
+++ b/code/firmware/rosco_m68k_firmware/video9958/vdpcon.asm
@@ -86,7 +86,7 @@ HAVE_V9958::
 
     ; Install temp bus error handler in case card not installed
     move.l  $8,BERR_SAVED
-    move.l  #.POST_WRITE,SDB_STATUS   ; In case we're on 68000, give a return address...
+    move.l  #.POST_WRITE,BERR_CONT_ADDR   ; In case we're on 68000, give a return address...
     move.l  #BERR_HANDLER,$8
 
     ; Zero Bus Error flag

--- a/code/firmware/rosco_m68k_firmware/video9958/vdpcon.asm
+++ b/code/firmware/rosco_m68k_firmware/video9958/vdpcon.asm
@@ -86,6 +86,7 @@ HAVE_V9958::
 
     ; Install temp bus error handler in case card not installed
     move.l  $8,BERR_SAVED
+    move.l  #.POST_WRITE,SDB_STATUS   ; In case we're on 68000, give a return address...
     move.l  #BERR_HANDLER,$8
 
     ; Zero Bus Error flag
@@ -93,6 +94,7 @@ HAVE_V9958::
 
     move.b  #1,(PORT_WREG_SETUP,A0)   ; Write 1 (SR#1)...\
 
+.POST_WRITE:
     tst.b   BERR_FLAG                 ; Was there a bus error?
     bne.s   .NO_9958                  ; Bail now if so...
    

--- a/code/firmware/rosco_m68k_firmware/video9958/vdpcon.asm
+++ b/code/firmware/rosco_m68k_firmware/video9958/vdpcon.asm
@@ -84,13 +84,8 @@ HAVE_V9958::
     movem.l D1/A0-A1,-(A7)
     move.l  #PORT_RWDATA,A0           ; Use A0 as port base register
 
-    ; Install temp bus error handler in case card not installed
-    move.l  $8,BERR_SAVED
+    jsr     INSTALL_TEMP_BERR_HANDLER     ; Install temporary bus error handler
     move.l  #.POST_WRITE,BERR_CONT_ADDR   ; In case we're on 68000, give a return address...
-    move.l  #BERR_HANDLER,$8
-
-    ; Zero Bus Error flag
-    move.b  #0,BERR_FLAG
 
     move.b  #1,(PORT_WREG_SETUP,A0)   ; Write 1 (SR#1)...\
 

--- a/code/firmware/rosco_m68k_firmware/videoXoseraANSI/xosera_ansiterm_init.asm
+++ b/code/firmware/rosco_m68k_firmware/videoXoseraANSI/xosera_ansiterm_init.asm
@@ -46,10 +46,12 @@ XANSI_CON_DATA_END      equ     $57F            ; 128 bytes reserved (~0x60 used
 XANSI_HAVE_XOSERA::
                 move.l  a0,-(sp)
                 jsr     INSTALL_TEMP_BERR_HANDLER
+                move.l  #.POST_WRITE,SDB_STATUS
 
                 move.l  #XM_BASEADDR,a0
                 move.b  (a0),d0
 
+.POST_WRITE:
                 tst.b   BERR_FLAG
                 bne.s   .NOXVID
 

--- a/code/firmware/rosco_m68k_firmware/videoXoseraANSI/xosera_ansiterm_init.asm
+++ b/code/firmware/rosco_m68k_firmware/videoXoseraANSI/xosera_ansiterm_init.asm
@@ -46,7 +46,7 @@ XANSI_CON_DATA_END      equ     $57F            ; 128 bytes reserved (~0x60 used
 XANSI_HAVE_XOSERA::
                 move.l  a0,-(sp)
                 jsr     INSTALL_TEMP_BERR_HANDLER
-                move.l  #.POST_WRITE,SDB_STATUS
+                move.l  #.POST_WRITE,BERR_CONT_ADDR
 
                 move.l  #XM_BASEADDR,a0
                 move.b  (a0),d0

--- a/code/software/memcheck/memcheck.c
+++ b/code/software/memcheck/memcheck.c
@@ -399,6 +399,11 @@ int main(int argc, char **argv) {
   delay(180000);  // wait a bit for terminal window/serial
   show_banner();
 
+  if (GET_CPU_ID() == 0) {
+    printf("Memcheck requires 68010 or higher, but found a 68000; Exiting\n\n");
+    return 1;
+  }
+
   INSTALL_BERR_HANDLER();
 
   printf("Building memory map, please wait this may take a while...\n\n");

--- a/code/software/software.mk
+++ b/code/software/software.mk
@@ -9,7 +9,7 @@ endif
 
 -include $(ROSCO_M68K_DIR)/user.mk
 
-CPU?=68010
+CPU?=68000
 ARCH?=$(CPU)
 TUNE?=$(CPU)
 


### PR DESCRIPTION
Happy to discuss this one, it's kind of a big change (conceptually, if not actually from the code POV).

* Support device probing on 68000 CPUs (with a bit of stack hackery in the bus error handler)
* Switch default CPU for Firmware build to be "lowest comment denominator" 68000
* Switch default CPU for software to 68000 for the same reasons
* Fail fast (and polite) in memcheck on 68000

Additionally, this:

* Prepares ATA / IDE for (possible) future deprecation / removal from standard build

This just means I made a new make option `WITH_ATA` - I needed this bit while developing, and it seemed like it could be useful down the line so left it in. It's on by default (so no change).

I have tested this on 68000, 68010 and it seems fine. ~If anyone has a populated 020 handy it would be good to double check it hasn't broken anything there~ **Edit: This has now been successfully tested on 020 as well**. 

Proof of life, no rebuild between these runs - just yanking and moving the chips:

<img width="566" alt="Screenshot 2023-11-19 at 21 47 36" src="https://github.com/rosco-m68k/rosco_m68k/assets/2096421/5adf6fbb-f371-4d96-889d-f23c300b41d5">
