### PR TITLE
Restore use of BERR_CONT_ADDR in Xosera probing for 68000

### DIFF
--- a/code/firmware/rosco_m68k_firmware/videoXoseraANSI/xosera_ansiterm_init.asm
+++ b/code/firmware/rosco_m68k_firmware/videoXoseraANSI/xosera_ansiterm_init.asm
@@ -46,10 +46,12 @@ XANSI_CON_DATA_END      equ     $57F            ; 128 bytes reserved (~0x60 used
 XANSI_HAVE_XOSERA::
                 move.l  a0,-(sp)
                 jsr     INSTALL_TEMP_BERR_HANDLER
+                move.l  #.POST_WRITE,BERR_CONT_ADDR
 
                 move.l  #XM_BASEADDR,a0
                 move.b  (a0),d0
 
+.POST_WRITE:
                 tst.b   BERR_FLAG
                 bne.s   .NOXVID
 


### PR DESCRIPTION
In #411, the writing a continuation address to `BERR_CONT_ADDR` was removed, which should cause issues if the Xosera is not present on a system with an MC68000.

I'm not aware of a reason to have this removed, this PR adds back in that operation.