### PR TITLE
Don't write to OPCR on DUART SPI read

### DIFF
--- a/code/firmware/rosco_m68k_firmware/blockdev/dua_spi_asm.asm
+++ b/code/firmware/rosco_m68k_firmware/blockdev/dua_spi_asm.asm
@@ -153,7 +153,7 @@ spi_read_buffer::
                 moveq.l #SPI_CIPO_B,d2          ;    4  d2 = CIPO bit num
                                                 ;       d3 = temp bit
                                                 ;       d4 = temp byte
-                move.b  #RED_LED,(a1)           ;   12  RED LED on (active LO)
+                move.b  #RED_LED,(a2)           ;   12  RED LED on (active LO)
 .spi_rb_loop:
             rept    8
 ; read bits 7...0
@@ -169,7 +169,7 @@ spi_read_buffer::
                 subq.l  #1,d0                   ;    8  decrement count
                 bne.s   .spi_rb_loop            ; 8/10  loop if not zero
 
-                move.b  #RED_LED,(a2)           ;   12  RED LED off (active LO)
+                move.b  #RED_LED,(a3)           ;   12  RED LED off (active LO)
                 movem.l (a7)+,d2-d4/a2-a3       ;12+40  restore regs
                 rts
 


### PR DESCRIPTION
As pointed out by bolishagnasty in DIscord, the red LED doesn't behave as documented.

I noticed in testing that red LED would act normally when an SD card wasn't used, but would stay on but more dimly when one is installed (suggesting that it's flashing quickly).

It turns out the the instructions that set and clear the red LED in `spi_read_buffer` is the same as in `spi_send_buffer`, but the register that the use have different values between the two functions. This led to data being written to `Output Port Configuration Register` instead of `Set Output Port Bits Command` and to `Set Output Port Bits Command` instead of `Clear Output Port Bits Command`.

This bug was changing the mode of OP3 to be a UART TX clock output instead of having the value set via the output port bits command registers, leading to the red LED being always-on when `spi_read_buffer` was called.

I don't know whether or not having the red LED still flash on SPI accesses is intended. It doesn't check the SDB system flags for whether the system is allowed to use the red LED, so the flashing should be removed or should check the flag, or the documentation should be updated. Either way, I've put this fix here to at least have what's there behave as intended.