### PR TITLE
Make LED respect SYSFLAGS and don't write to OPCR on DUART SPI read

### DIFF
--- a/code/firmware/rosco_m68k_firmware/blockdev/dua_spi_asm.asm
+++ b/code/firmware/rosco_m68k_firmware/blockdev/dua_spi_asm.asm
@@ -82,6 +82,9 @@ spi_send_buffer::
                 moveq.l #SPI_SCK|SPI_COPI,d4    ;    4  d4 = SCK|COPI bit mask
                                                 ;       d5 = temp COPI LO
                                                 ;       d6 = temp COPI HI
+
+                btst.b  #1,SDB_SYSFLAGS         ;    8  Is sysflag (high byte) bit 1 set?
+                beq.s   .spi_sb_loop            ; 6/10  skip if not...
                 move.b  #RED_LED,(a1)           ;   12  RED LED on (active LO)
 
 .spi_sb_loop:   move.b  (a0)+,d1                ;    8  load send byte
@@ -102,8 +105,11 @@ spi_send_buffer::
                 subq.l  #1,d0
                 bne     .spi_sb_loop  
 
+                btst.b  #1,SDB_SYSFLAGS         ;    8  Is sysflag (high byte) bit 1 set?
+                beq.s   .spi_sb_done            ; 6/10  skip if not...
                 move.b  #RED_LED,(a2)           ;   12  RED LED off (active LO)
-                movem.l (a7)+,d2-d6/a2          ;12+48  restore regs
+
+.spi_sb_done:   movem.l (a7)+,d2-d6/a2          ;12+48  restore regs
                 rts
 
 ; read byte from DUART GPIO SPI
@@ -153,7 +159,11 @@ spi_read_buffer::
                 moveq.l #SPI_CIPO_B,d2          ;    4  d2 = CIPO bit num
                                                 ;       d3 = temp bit
                                                 ;       d4 = temp byte
+
+                btst.b  #1,SDB_SYSFLAGS         ;    8  Is sysflag (high byte) bit 1 set?
+                beq.s   .spi_rb_loop            ; 6/10  skip if not...
                 move.b  #RED_LED,(a2)           ;   12  RED LED on (active LO)
+
 .spi_rb_loop:
             rept    8
 ; read bits 7...0
@@ -169,8 +179,11 @@ spi_read_buffer::
                 subq.l  #1,d0                   ;    8  decrement count
                 bne.s   .spi_rb_loop            ; 8/10  loop if not zero
 
+                btst.b  #1,SDB_SYSFLAGS         ;    8  Is sysflag (high byte) bit 1 set?
+                beq.s   .spi_rb_done            ; 6/10  skip if not...
                 move.b  #RED_LED,(a3)           ;   12  RED LED off (active LO)
-                movem.l (a7)+,d2-d4/a2-a3       ;12+40  restore regs
+
+.spi_rb_done:   movem.l (a7)+,d2-d4/a2-a3       ;12+40  restore regs
                 rts
 
             ifd WIP_UNTESTED_CODE               ; untested below, ignore

--- a/code/firmware/rosco_m68k_firmware/blockdev/dua_spi_asm.asm
+++ b/code/firmware/rosco_m68k_firmware/blockdev/dua_spi_asm.asm
@@ -153,7 +153,7 @@ spi_read_buffer::
                 moveq.l #SPI_CIPO_B,d2          ;    4  d2 = CIPO bit num
                                                 ;       d3 = temp bit
                                                 ;       d4 = temp byte
-                move.b  #RED_LED,(a1)           ;   12  RED LED on (active LO)
+                move.b  #RED_LED,(a2)           ;   12  RED LED on (active LO)
 .spi_rb_loop:
             rept    8
 ; read bits 7...0
@@ -169,7 +169,7 @@ spi_read_buffer::
                 subq.l  #1,d0                   ;    8  decrement count
                 bne.s   .spi_rb_loop            ; 8/10  loop if not zero
 
-                move.b  #RED_LED,(a2)           ;   12  RED LED off (active LO)
+                move.b  #RED_LED,(a3)           ;   12  RED LED off (active LO)
                 movem.l (a7)+,d2-d4/a2-a3       ;12+40  restore regs
                 rts
 

--- a/code/firmware/rosco_m68k_firmware/rev1.asm
+++ b/code/firmware/rosco_m68k_firmware/rev1.asm
@@ -33,7 +33,6 @@ STOP_HEART::
 ; Exception handlers    
 TICK_HANDLER::
     move.l  D0,-(A7)                  ; Save D0
-    move.l  D1,-(A7)                  ; Save D1
 
     ; Increment upticks
     move.l  SDB_UPTICKS,D0            ; Read SDB dword at 12
@@ -48,11 +47,8 @@ TICK_HANDLER::
     ; counted to zero, so toggle indicator 0 (if allowed) 
     ; and reset counter
     move.b  SDB_SYSFLAGS,D0           ; Get sysflags (high byte)
-
-    move.b  MFP_GPDR,D1               ; Get GPDR
-    eor.b   #1,D1                     ; Toggle bit 0
-    and.b   D0,D1                     ; Mask with flags
-    move.b  D1,MFP_GPDR               ; Set GPDR
+    and.b   #1,D0                     ; Mask bit 0 to toggle with flags
+    eor.b   D0,MFP_GPDR               ; Toggle GPDR
 
     move.w  #50,D0                    ; Reset counter
 
@@ -60,7 +56,6 @@ TICK_HANDLER::
 
     sub.w   #$1,D0                    ; Decrement counter...
     move.w  D0,SDB_TICKCNT            ; ... and write back to SDB
-    move.l  (A7)+,D1                  ; Restore D1
 
     move.b  #~$20,MFP_ISRB            ; Clear interrupt-in-service
     move.l  (A7)+,D0                  ; Restore D0

--- a/code/firmware/rosco_m68k_firmware/rev2.asm
+++ b/code/firmware/rosco_m68k_firmware/rev2.asm
@@ -67,8 +67,7 @@ TICK_HANDLER::
     
     ; counted to zero, so toggle indicator 0 (if allowed) 
     ; and reset counter
-    move.b  SDB_SYSFLAGS,D1           ; Get sysflags (high byte)
-    btst    #1,D1                     ; Is sysflag bit 1 set?
+    btst.b  #0,SDB_SYSFLAGS           ; Is sysflag (high byte) bit 0 set?
     beq.s   .TICKRESET                ; bail now if not...
 
     move.b  SDB_INTFLAGS,D1

--- a/code/firmware/rosco_m68k_firmware/stage2/init2.asm
+++ b/code/firmware/rosco_m68k_firmware/stage2/init2.asm
@@ -24,10 +24,9 @@ START::
 
 red_led_off::
     ifd REVISION1X
-    move.b  MFP_GPDR,D0                 ; Get GPDR
-    or.b    #2,D0                       ; Turn off I1
-    and.b   D1,D0                       ; Mask with flags
-    move.b  D0,MFP_GPDR                 ; Set GPDR
+    move.b  SDB_SYSFLAGS,D0             ; Get sysflags (high byte)
+    and.b   #2,D0                       ; Turn off I1
+    or.b    D0,MFP_GPDR                 ; Update GPDR
     else
     move.l  SDB_UARTBASE,A0
     move.b  #$08,W_OPR_RESETCMD(A0)     ; Turn off red LED on r2.x boards

--- a/code/firmware/rosco_m68k_firmware/stage2/init2.asm
+++ b/code/firmware/rosco_m68k_firmware/stage2/init2.asm
@@ -28,7 +28,10 @@ red_led_off::
     and.b   #2,D0                       ; Turn off I1
     or.b    D0,MFP_GPDR                 ; Update GPDR
     else
+    btst.b  #1,SDB_SYSFLAGS             ; Is sysflag (high byte) bit 1 set?
+    beq.s   .no_red_led_off             ; skip if not...
     move.l  SDB_UARTBASE,A0
     move.b  #$08,W_OPR_RESETCMD(A0)     ; Turn off red LED on r2.x boards
+.no_red_led_off:
     endif
     rts


### PR DESCRIPTION
This PR includes the changes in #419 (see that PR for details on those changes) as well as additional ones to prevent the GPIOs from being incorrectly changed when the LEDs are controlled and SYSFLAGS sets them as not available to the firmware.

It adds checks to `spi_send_buffer` and `spi_read_buffer` in dua_spi_asm.asm to only set/clear the red LED if the corresponding SYSFLAGS bit is set.

There were also cases where the SYSFLAGS were and-ed with the value to set in the MFP GPDR, which seemingly would clear those bits, instead of leaving them untouched. I've changed this here to use RMW instructions with an already-masked value to directly only update the bits that are allowed by the SYSFLAGS.

I have only tested the behaviour on r2 boards with DUART, not on the r1.x with MFP. EDIT: I have now also tested that the system still works with these changes on a HUGEROM r1.23 with MFP, but haven't thoroughly tested how the LEDs behave.