### PR TITLE
Fix an issue whereby we stomped .early_data which broke character devs

### DIFF
--- a/code/firmware/rosco_m68k_firmware/rosco_m68k_firmware_common.ld
+++ b/code/firmware/rosco_m68k_firmware/rosco_m68k_firmware_common.ld
@@ -36,7 +36,6 @@ SECTIONS
 
   .data : ALIGN(4)
   {
-    *(.early_data*)
     _data_start = .;
     _data_load_start = _data_start - ADDR(.data) + LOADADDR(.data);
     *(.data*)
@@ -44,12 +43,17 @@ SECTIONS
     _data_load_end = _data_end - ADDR(.data) + LOADADDR(.data);
   } >KRES2 AT>FLASH
 
-   .bss (NOLOAD) : ALIGN(4)
+  .bss (NOLOAD) : ALIGN(4)
   {
     _bss_start = .;
     *(.bss*)
     _bss_end = .;
   } >KRES2
+
+  .earlydata : ALIGN(4)
+  {
+    *(.early_data*)
+  } >KRES2 AT>FLASH
 
   .zipdata : ALIGN(4)
   {

--- a/code/firmware/rosco_m68k_firmware/stage1/keyboard.c
+++ b/code/firmware/rosco_m68k_firmware/stage1/keyboard.c
@@ -53,44 +53,71 @@ static bool detect_keyboard(CharDevice *device) {
         chr = try_get_char(device);
         if (chr != *id_str++) {
             return false;
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad ident\r\n");
+#endif
         }
     }
 
     chr = try_get_char(device);
     if (chr != IDENT_MODE_ASCII) {
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad mode\r\n");
+#endif
         return false;
     }
 
     chr = try_get_char(device);
     if (chr == -1) {    // key count
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad key count\r\n");
+#endif
         return false;
     }
 
     chr = try_get_char(device);
     if (chr == -1) {    // led count
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad LED count\r\n");
+#endif
         return false;
     }
 
     chr = try_get_char(device);
     if (chr == -1) {    // capabilities
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad capabilities\r\n");
+#endif
         return false;
     }
 
     chr = try_get_char(device);
     if (chr != 0) {     // reserved - must be 0
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad reserved\r\n");
+#endif
         return false;
     }
 
     chr = try_get_char(device);
     if (chr != 0) {     // reserved2 - must be 0
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad reserved 2\r\n");
+#endif
         return false;
     }
 
     chr = try_get_char(device);
     if (chr != CMD_ACK) {   // required ack
+#ifdef DEBUG_KEYBOARD_DETECT
+        FW_PRINT_C("Bad ack\r\n");
+#endif
         return false;
     }
 
+#ifdef DEBUG_KEYBOARD_DETECT
+    FW_PRINT_C("Detect success\r\n");
+#endif
     return true;
 }
 


### PR DESCRIPTION
### To replicate:

* Add `#include DEBUG_KEYBOARD_DETECT` at the top of `stage1/keyboard.c`
* Try to run keyboard - see `Error: Insufficient character devices`

### The issue:

`DEVICE_COUNT` is in the `.earlydata` section, which gets rolled in to `.data` and so is copied during `linit`. 
**However** it's already been populated before that, during DUART or MFP init - and copying it sets it back to zero (by copying its "source" data from ROM). This happens because the data copy just starts from code end, which is right where `.earlydata` is.

**Note** Although named `.earlydata` this section is poorly named - it's not really data, it's bss, but we also don't want it zeroed during `linit` either, since we've already set it up before `linit` is called. This is why it's called `.earlyXXX`.

### The fix

Just moved the section up after bss in KRAM, and made it not be part of `.data` in the link script.

I could also have made the copy a bit more robust and had it start from `.data_start` or whatever that symbol is called, but this way seemed to make it more clear that, despite the name, this _isn't_ data and doesn't belong in its section.