### PR TITLE
WIP: Feature/remove bare metal toolchain dependency

### DIFF
--- a/code/Toolchain.md
+++ b/code/Toolchain.md
@@ -10,7 +10,7 @@ toolchain with the following commands:
 
 ```bash
 brew tap rosco-m68k/toolchain
-brew install gcc-cross-m68k@11 vasm-m68k srecord minipro
+brew install rosco-m68k-toolchain@13.rb srecord minipro
 ```
 
 This will automatically download, build and install all the dependencies that
@@ -20,6 +20,10 @@ It'll take a few minutes, as it builds binutils and GCC from source. Once it's
 done, you're ready to rock.
 
 ## The Slightly-Less Easy Way - Building the Toolchain
+
+See https://github.com/rosco-m68k/newlib-rosco-build/blob/main/README.md
+
+## The Old Way - Building the Bare Metal Toolchain (advanced users)
 
 0. Configure build environment (Linux only)
 

--- a/code/firmware/rosco_m68k_firmware/stage1/debug_stub/debug_stub.asm
+++ b/code/firmware/rosco_m68k_firmware/stage1/debug_stub/debug_stub.asm
@@ -17,7 +17,7 @@
 ; Often with just the PC crash address you can narrow down the source code
 ; causing the problem with e.g:
 ;
-; m68k-elf-addr2line -e myprogram.elf 0x1234
+; m68k-elf-rosco-addr2line -e myprogram.elf 0x1234
 ;
 ; This will often give a line "near" the problem (usually after the actual
 ; cause), but is still very helpful.

--- a/code/firmware/rosco_m68k_firmware/stage2/Makefile
+++ b/code/firmware/rosco_m68k_firmware/stage2/Makefile
@@ -11,6 +11,7 @@ include ../common.mk
 
 CC=m68k-elf-rosco-gcc
 LD=m68k-elf-rosco-gcc
+OBJCOPY=m68k-elf-rosco-objcopy
 
 CFLAGS=																	\
 	-std=c11 -g -nostartfiles --param=min-pagesize=0					\
@@ -108,7 +109,7 @@ $(BINARY_ZIP): $(BINARY) $(LZG)
 	$(LZG) -9 $< $@
 
 $(BINARY_ZIP_OBJ): $(BINARY_ZIP)
-	m68k-elf-objcopy -I binary -O elf32-m68k -B m68k --rename-section .data=.zipdata $< $@
+	$(OBJCOPY) -I binary -O elf32-m68k -B m68k --rename-section .data=.zipdata $< $@
 
 ifneq ($(XOSERA_API_MINIMAL),false)
 boot_menu/libboot_menu.a:

--- a/code/software/dhrystone/dhrystone.c
+++ b/code/software/dhrystone/dhrystone.c
@@ -583,7 +583,7 @@ void Proc0()
 		Proc4();
 		IntLoc1 = 2;
 		IntLoc2 = 3;
-		IntLoc3 = 0;	// Xark: m68k-elf-gcc -O1 forces this (with -O2 it figures it out)
+		IntLoc3 = 0;	// Xark: m68k-elf-rosco-gcc -O1 forces this (with -O2 it figures it out)
 		strcpy(String2Loc, "DHRYSTONE PROGRAM, 2'ND STRING");
 		EnumLoc = Ident2;
 		BoolGlob = ! Func2(String1Loc, String2Loc);

--- a/code/software/libs/Makefile
+++ b/code/software/libs/Makefile
@@ -15,11 +15,11 @@ CFLAGS=-std=c11 $(FLAGS)
 CXXFLAGS=-std=c++20 -fno-exceptions -fno-rtti $(FLAGS)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES)
 ARFLAGS=
-CC=m68k-elf-gcc
-CXX=m68k-elf-g++
-LD=m68k-elf-ld
-AR=m68k-elf-ar
-RANLIB=m68k-elf-ranlib
+CC=m68k-elf-rosco-gcc
+CXX=m68k-elf-rosco-g++
+LD=m68k-elf-rosco-ld
+AR=m68k-elf-rosco-ar
+RANLIB=m68k-elf-rosco-ranlib
 AS=vasmm68k_mot
 RM_F=rm -f
 RM_RF=$(RM_F) -r

--- a/code/software/libs/README.md
+++ b/code/software/libs/README.md
@@ -1,4 +1,14 @@
-# Rosco_m68k Standard Libraries
+# Rosco_m68k Bare-Metal Standard Libraries
+
+> **Note**: These libraries are should only be used for legacy programs, or where 
+> bare-metal with minimal C runtime support is specifically needed.
+>
+> If you have a need to use these, you'll know why you need them and what you're
+> getting yourself into. You will need to compile free-standing and without standard
+> includes etc.
+>
+> For most use-cases, it is recommended to use the C libraries and support code that
+> comes with the `m68k-elf-rosco` toolchain. 
 
 This directory contains the standard libraries that support writing
 programs for the rosco_m68k. The libraries are contained in 
@@ -93,8 +103,8 @@ the correct linker script might be:
 
 ```
 export LIBDIR=../libs/build
-m68k-elf-gcc -ffreestanding -o kmain.o -c kmain.c
-m68k-elf-ld T $LIBDIR/ld/serial/rosco_m68k_program.ld -L $LIBDIR -o myprog.bin main.o -lstart_serial
+m68k-elf-rosco-gcc -ffreestanding -o kmain.o -c kmain.c
+m68k-elf-rosco-ld T $LIBDIR/ld/serial/rosco_m68k_program.ld -L $LIBDIR -o myprog.bin main.o -lstart_serial
 ```
 
 For a more complete example, see the `Makefile` in one of the example

--- a/code/software/libs/src/debug_stub/debug_stub.asm
+++ b/code/software/libs/src/debug_stub/debug_stub.asm
@@ -17,7 +17,7 @@
 ; Often with just the PC crash address you can narrow down the source code
 ; causing the problem with e.g:
 ;
-; m68k-elf-addr2line -e myprogram.elf 0x1234
+; m68k-elf-rosco-addr2line -e myprogram.elf 0x1234
 ;
 ; This will often give a line "near" the problem (usually after the actual
 ; cause), but is still very helpful.

--- a/code/software/libs/src/debug_stub/include/debug_stub.h
+++ b/code/software/libs/src/debug_stub/include/debug_stub.h
@@ -38,12 +38,12 @@
  *
  * If you have a rosco_m68k elf file, generated with debug information (-g)
  * then you can usually get the C source line of the code that caused the
- * exception (or close to it, often the line after) using m68k-elf-addr2line,
- * the "-e" option followed by your program elf file and the PC address from
- * the debug information printed (preceeded with "0x" for hex).  For example,
- * for the crash above:
+ * exception (or close to it, often the line after) using 
+ * m68k-elf-rosco-addr2line, the "-e" option followed by your program elf 
+ * file and the PC address from the debug information printed (preceeded 
+ * with "0x" for hex).  For example, for the crash above:
  *
- * m68k-elf-addr2line -e example.elf 0x115A
+ * m68k-elf-rosco-addr2line -e example.elf 0x115A
  *
  * NOTE: On 68010/12 CPUs the PC counter (and "op") may be up to five words
  * ahead of the actual location where the exception occurred on a bus or

--- a/code/software/libs/src/start_serial/README.md
+++ b/code/software/libs/src/start_serial/README.md
@@ -9,8 +9,8 @@ the correct linker script might be:
 
 ```bash
 export LIBDIR=../libs/build
-m68k-elf-gcc -ffreestanding -o kmain.o -c kmain.c
-m68k-elf-ld T $LIBDIR/ld/serial/rosco_m68k_program.ld -L $LIBDIR -o myprog.bin main.o -lstart_serial
+m68k-elf-rosco-gcc -ffreestanding -o kmain.o -c kmain.c
+m68k-elf-rosco-ld T $LIBDIR/ld/serial/rosco_m68k_program.ld -L $LIBDIR -o myprog.bin main.o -lstart_serial
 ```
 
 For a more complete example, see the `Makefile` in one of the example

--- a/code/software/software.mk
+++ b/code/software/software.mk
@@ -31,21 +31,21 @@ CXXFLAGS=-std=c++20 -fno-exceptions -fno-rtti $(FLAGS)
 GCC_LIBS?=$(shell $(CC) --print-search-dirs \
           | grep libraries:\ = \
           | sed 's/libraries: =/-L/g' \
-          | sed 's/:/m68000\/ -L/g')m68000/
+          | sed 's/:/\/ -L/g')
 LIBS=$(EXTRA_LIBS) -lprintf -lcstdlib -lmachine -lstart_serial -lgcc
 ASFLAGS=-mcpu=$(CPU) -march=$(ARCH)
 VASMFLAGS=-Felf -m$(CPU) -quiet -Lnf $(DEFINES)
 LDFLAGS=-T $(LDSCRIPT) -L $(SYSLIBDIR) -Map=$(MAP) --gc-sections --oformat=elf32-m68k $(EXTRA_LDFLAGS)
 
-CC=m68k-elf-gcc
-CXX=m68k-elf-g++
-AS=m68k-elf-as
-LD=m68k-elf-ld
-NM=m68k-elf-nm
-LD=m68k-elf-ld
-OBJDUMP=m68k-elf-objdump
-OBJCOPY=m68k-elf-objcopy
-SIZE=m68k-elf-size
+CC=m68k-elf-rosco-gcc
+CXX=m68k-elf-rosco-g++
+AS=m68k-elf-rosco-as
+LD=m68k-elf-rosco-ld
+NM=m68k-elf-rosco-nm
+LD=m68k-elf-rosco-ld
+OBJDUMP=m68k-elf-rosco-objdump
+OBJCOPY=m68k-elf-rosco-objcopy
+SIZE=m68k-elf-rosco-size
 VASM=vasmm68k_mot
 RM=rm -f
 CP=cp

--- a/code/tools/r68k/firmware/Makefile
+++ b/code/tools/r68k/firmware/Makefile
@@ -14,13 +14,13 @@ CFLAGS=-std=c11 -ffreestanding -nostartfiles -Wall -Wpedantic -Werror		\
        $(DEFINES)
 LDFLAGS=-T ./rosco_m68k_translator.ld -Map=$(MAP)
 ASFLAGS=-Felf -m$(CPU) -quiet $(DEFINES) -align
-CC=m68k-elf-gcc
-LD=m68k-elf-ld
+CC=m68k-elf-rosco-gcc
+LD=m68k-elf-rosco-ld
 AS=vasmm68k_mot
-OBJCOPY=m68k-elf-objcopy
-OBJDUMP=m68k-elf-objdump
-SIZE=m68k-elf-size
-NM=m68k-elf-nm
+OBJCOPY=m68k-elf-rosco-objcopy
+OBJDUMP=m68k-elf-rosco-objdump
+SIZE=m68k-elf-rosco-size
+NM=m68k-elf-rosco-nm
 RM=rm -f
 
 # Output config

--- a/code/tools/r68k/firmware/debug_stub/debug_stub.asm
+++ b/code/tools/r68k/firmware/debug_stub/debug_stub.asm
@@ -17,7 +17,7 @@
 ; Often with just the PC crash address you can narrow down the source code
 ; causing the problem with e.g:
 ;
-; m68k-elf-addr2line -e myprogram.elf 0x1234
+; m68k-elf-rosco-addr2line -e myprogram.elf 0x1234
 ;
 ; This will often give a line "near" the problem (usually after the actual
 ; cause), but is still very helpful.


### PR DESCRIPTION
> **N.B. This needs to go after https://github.com/rosco-m68k/rosco_m68k/pull/431 and will need rebasing on `develop` once that one's merged**.
>
> It's currently based on top of that to ensure everything gets picked up by the CI builds...

## Final removal of bare-metal toolchain dependency from all platform code

This PR takes the final steps to fully removing the dependency on the bare-metal (`m68k-elf-`) toolchain from all platform code, in favour of the new `m68k-elf-rosco` target toolchain (which has a newlib-based C library).

### In this PR:

* Remove bare-metal toolchain dependency from `code/software/libs`
* Remove bare-metal toolchain dependency from all examples under `code/software`
* Remove bare-metal toolchain dependency from `r68k` build
* Remove bare-metal references in docs, comments and other places

### Pre-work already merged

* Remove bare-metal toolchain dependency from firmware build

You can find the code for the `rosco` toolchain here: https://github.com/rosco-m68k/newlib-rosco-build