### PR TITLE
MAME can't support PMOVE MMUSR, use TC instead

### DIFF
--- a/code/firmware/rosco_m68k_firmware/stage1/cputype.asm
+++ b/code/firmware/rosco_m68k_firmware/stage1/cputype.asm
@@ -83,7 +83,7 @@ INIT_CPU_TYPE::
     ; point!
 
     mc68030
-    pmove   MMUSR,M16BUF              ; Try PMOVE
+    pmove   TC,M16BUF                 ; Try PMOVE
     mc68000
 .CONT3:
     tst.b   IIFLAG                    ; Was it illegal?


### PR DESCRIPTION
This _should_ make no difference externally, but allows MAME to run an 030 without crashing (the Musashi MMU doesn't support move from MMUSR by the looks of it, resulting in a crash).

Reported on Discord by Eschaton.