### PR TITLE
Wait for a keypress at the end of `debug_stub`

### DIFF
--- a/code/firmware/rosco_m68k_firmware/stage1/debug_stub/debug_stub.asm
+++ b/code/firmware/rosco_m68k_firmware/stage1/debug_stub/debug_stub.asm
@@ -221,6 +221,7 @@ debug_stub::
                 cmp.b   #16,d4
                 blt     .regloop
                 and.w   #$F0FF,sr               ; Re-enable interrupts
+                jsr     FW_INPUTCHAR            ; Wait for keypress
                 move.l  4.w,a0                  ; And warmboot
                 jmp     (a0)
 

--- a/code/firmware/rosco_m68k_firmware/stage1/debug_stub/debug_stub.asm
+++ b/code/firmware/rosco_m68k_firmware/stage1/debug_stub/debug_stub.asm
@@ -221,7 +221,12 @@ debug_stub::
                 cmp.b   #16,d4
                 blt     .regloop
                 and.w   #$F0FF,sr               ; Re-enable interrupts
-                jsr     FW_INPUTCHAR            ; Wait for keypress
+.clrbuf         jsr     FW_CHECKINPUT           ; Check for any existing characters in buffer
+                tst.b   d0                      ; Test return value, 0=empty, 1=characters available
+                beq.s   .bufclr                 ; If 0, no characters pending, wait for keypress
+                jsr     FW_INPUTCHAR            ; Else, character available, clear it
+                bra.s   .clrbuf                 ; Loop until input buffer cleared
+.bufclr         jsr     FW_INPUTCHAR            ; Wait for keypress
                 move.l  4.w,a0                  ; And warmboot
                 jmp     (a0)
 

--- a/code/firmware/rosco_m68k_firmware/stage1/include/machine.h
+++ b/code/firmware/rosco_m68k_firmware/stage1/include/machine.h
@@ -15,8 +15,9 @@
 #ifndef _ROSCOM68K_MACHINE_H
 #define _ROSCOM68K_MACHINE_H
 
-#include <stdnoreturn.h>
+#include <stdbool.h>
 #include <stdint.h>
+#include <stdnoreturn.h>
 
 #ifdef REVISION1X
 #define MFP_GPDR      0xf80001
@@ -209,6 +210,11 @@ char FW_RECVCHAR_C(void);
  * Firmware INPUTCHAR function (uses pointer at $494)
  */
 char FW_INPUTCHAR_C(void);
+
+/*
+ * Firmware CHECKINPUT function (uses pointer at $498)
+ */
+bool FW_CHECKINPUT_C(void);
 
 /*
  * Firmware CLRSCR function (uses pointer at $438)

--- a/code/firmware/rosco_m68k_firmware/stage1/include/machine.h
+++ b/code/firmware/rosco_m68k_firmware/stage1/include/machine.h
@@ -206,6 +206,11 @@ void FW_SENDCHAR_C(char ch);
 char FW_RECVCHAR_C(void);
 
 /*
+ * Firmware INPUTCHAR function (uses pointer at $494)
+ */
+char FW_INPUTCHAR_C(void);
+
+/*
  * Firmware CLRSCR function (uses pointer at $438)
  */
 void FW_CLRSCR_C(void);

--- a/code/firmware/rosco_m68k_firmware/stage1/trap14.asm
+++ b/code/firmware/rosco_m68k_firmware/stage1/trap14.asm
@@ -251,6 +251,23 @@ FW_INPUTCHAR::
     move.l  (A7)+,A1
     rts
 
+; Wraps FW_CHECKINPUT so it can be called from C-land
+;
+; Modifies: D0 (return)
+FW_CHECKINPUT_C::
+    ; Fall through to FW_CHECKINPUT
+
+; Checks the default input device for a waiting character.
+;
+; Trashes: Nothing
+; Modifies: D0 (return)
+FW_CHECKINPUT::
+    move.l  A1,-(A7)
+    move.l  EFP_CHECKINPUT,A1
+    jsr     (A1)
+    move.l  (A7)+,A1
+    rts
+
 ; Wraps FW_CLRSCR so it can be called from C-land
 ;
 ; Modifies: Nothing

--- a/code/firmware/rosco_m68k_firmware/stage1/trap14.asm
+++ b/code/firmware/rosco_m68k_firmware/stage1/trap14.asm
@@ -233,6 +233,24 @@ FW_RECVCHAR::
     move.l  (A7)+,A1
     rts
 
+; Wraps FW_INPUTCHAR so it can be called from C-land
+;
+; Modifies: D0 (return)
+FW_INPUTCHAR_C::
+    ; Fall through to FW_INPUTCHAR
+
+; Receive a single character via default input device.
+; Ignores UART overrun errors.
+;
+; Trashes: Nothing
+; Modifies: D0 (return)
+FW_INPUTCHAR::
+    move.l  A1,-(A7)
+    move.l  EFP_INPUTCHAR,A1
+    jsr     (A1)
+    move.l  (A7)+,A1
+    rts
+
 ; Wraps FW_CLRSCR so it can be called from C-land
 ;
 ; Modifies: Nothing


### PR DESCRIPTION
This PR adds `FW_INPUTCHAR` and `FW_CHECKINPUT` (as well as their ...`_C` variants for symmetry) and blocks on `FW_INPUTCHAR` right before warmboot at the end of `debug_stub`.

With the second commit in the PR, there is a loop with `FW_CHECKINPUT` and `FW_INPUTCHAR` to clear the input buffer of pending characters before blocking with a final `FW_INPUTCHAR`.

This fixes #459.