### PR TITLE
Fix typo in PRINTCHAR description

### DIFF
--- a/code/firmware/rosco_m68k_firmware/InterfaceReference.md
+++ b/code/firmware/rosco_m68k_firmware/InterfaceReference.md
@@ -753,7 +753,7 @@ Nothing
 
 **Description**
 
-Print the character in `D0.B` to by `A0` to the system's *default console*.
+Print the character in `D0.B` to the system's *default console*.
 
 Where the default console is a serial terminal, this routine may block until
 there is space in the UART's transmit buffer for the character - as such, 


### PR DESCRIPTION
As pointed out by @BoliShag in #476, there was a typo in the description for `PRINTCHAR`, where a part of the sentence for the string printing was left in.

This PR fixes #476 by correcting this typo.